### PR TITLE
fix vpnkit buffer size + support slirp4netns

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -33,7 +33,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "net",
-			Usage: "host, vdeplug_slirp, vpnkit",
+			Usage: "host, vdeplug_slirp, vpnkit, slirp4netns",
 			Value: "host",
 		},
 		cli.StringFlag{
@@ -97,6 +97,8 @@ func parseNetworkMode(s string) (common.NetworkMode, error) {
 		return common.VDEPlugSlirp, nil
 	case "vpnkit":
 		return common.VPNKit, nil
+	case "slirp4netns":
+		return common.Slirp4NetNS, nil
 	default:
 		return -1, errors.Errorf("unknown network mode: %s", s)
 	}

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -188,8 +188,8 @@ func setupNet(msg *common.Message, etcWasCopied bool) error {
 	}
 	tap := ""
 	switch msg.NetworkMode {
-	case common.VDEPlugSlirp:
-		tap = msg.VDEPlugTap
+	case common.VDEPlugSlirp, common.Slirp4NetNS:
+		tap = msg.PreconfiguredTap
 	case common.VPNKit:
 		var err error
 		tap, err = startVPNKitRoutines(context.TODO(),

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -151,7 +151,7 @@ func startVPNKitRoutines(ctx context.Context, macStr, socket, uuidStr string) (s
 }
 
 func tap2vif(vif *vpnkit.Vif, r io.Reader) {
-	b := make([]byte, 1500)
+	b := make([]byte, 65536)
 	for {
 		n, err := r.Read(b)
 		if err != nil {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -6,6 +6,7 @@ const (
 	HostNetwork NetworkMode = iota
 	VDEPlugSlirp
 	VPNKit
+	Slirp4NetNS
 )
 
 type CopyUpMode int

--- a/pkg/common/message.go
+++ b/pkg/common/message.go
@@ -7,11 +7,13 @@ type Message struct {
 	StateDir string
 	// Network settings
 	NetworkMode
-	IP           string
-	Netmask      int
-	Gateway      string
-	DNS          string
-	VDEPlugTap   string
+	IP      string
+	Netmask int
+	Gateway string
+	DNS     string
+	// For vdeplug_slirp and slirp4netns
+	PreconfiguredTap string
+	// VPNKit settings
 	VPNKitMAC    string
 	VPNKitSocket string
 	VPNKitUUID   string

--- a/pkg/parent/parent.go
+++ b/pkg/parent/parent.go
@@ -110,6 +110,12 @@ func Parent(pipeFDEnvKey string, opt *Opt) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to setup vpnkit")
 		}
+	case common.Slirp4NetNS:
+		cleanupSlirp4NetNS, err := setupSlirp4NetNS(cmd.Process.Pid, &msg)
+		defer cleanupSlirp4NetNS()
+		if err != nil {
+			return errors.Wrap(err, "failed to setup slirp4netns")
+		}
 	}
 
 	// wake up the child


### PR DESCRIPTION
Host:

```console
$ iperf3 -c 127.0.0.1 -t 30
...
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-30.00  sec   153 GBytes  44.0 Gbits/sec    2             sender
[  4]   0.00-30.00  sec   153 GBytes  44.0 Gbits/sec                  receiver
```

VPNKit:

```console
$ rootlesskit --net=vpnkit iperf3 -c 192.168.65.2 -t 30
...
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-30.00  sec  1.44 GBytes   413 Mbits/sec    0             sender
[  4]   0.00-30.00  sec  1.44 GBytes   412 Mbits/sec                  receiver
```

vdeplug_slirp:

```console
$ rootlesskit --net=vdeplug_slirp iperf3 -c 10.0.2.2 -t 30
...
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-30.00  sec   787 MBytes   220 Mbits/sec    0             sender
[  4]   0.00-30.00  sec   787 MBytes   220 Mbits/sec                  receiver
```

[slirp4netns](https://github.com/AkihiroSuda/slirp4netns):

```console
$ rootlesskit --net=slirp4netns iperf3 -c 10.0.2.2 -t 30
...
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-30.00  sec  1.83 GBytes   523 Mbits/sec    0             sender
[  4]   0.00-30.00  sec  1.83 GBytes   523 Mbits/sec                  receiver
```

slirp4netns is faster than VPNKit but still extremely slow compared to the loopback devce :cry: 

TODO: increase TAP MTU from 1500 to 65536

fix #6 
cc @tonistiigi @djs55