### PR TITLE
add `127.0.0.1 $HOSTNAME` to /etc/hosts

### DIFF
--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -214,12 +214,18 @@ func setupNet(msg *common.Message, etcWasCopied bool) error {
 		if err := writeResolvConf(msg.DNS); err != nil {
 			return err
 		}
+		if err := writeEtcHosts(); err != nil {
+			return err
+		}
 	} else {
 		logrus.Warn("Mounting /etc/resolv.conf without copying-up /etc. " +
 			"Note that /etc/resolv.conf in the namespace will be unmounted when it is recreated on the host. " +
 			"Unless /etc/resolv.conf is statically configured, copying-up /etc is highly recommended. " +
 			"Please refer to RootlessKit documentation for further information.")
 		if err := mountResolvConf(msg.StateDir, msg.DNS); err != nil {
+			return err
+		}
+		if err := mountEtcHosts(msg.StateDir); err != nil {
 			return err
 		}
 	}

--- a/pkg/child/hosts.go
+++ b/pkg/child/hosts.go
@@ -1,0 +1,66 @@
+package child
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/rootless-containers/rootlesskit/pkg/common"
+)
+
+// generateEtcHosts makes sure the current hostname is resolved into
+// 127.0.0.1 or ::1, not into the host eth0 IP address.
+//
+// Note that /etc/hosts is not used by nslookup/dig. (Use `getent ahostsv4` instead.)
+func generateEtcHosts() ([]byte, error) {
+	etcHosts, err := ioutil.ReadFile("/etc/hosts")
+	if err != nil {
+		return nil, err
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	// FIXME: no need to add the entry if already added
+	s := fmt.Sprintf("%s\n127.0.0.1 %s\n::1 %s\n",
+		string(etcHosts), hostname, hostname)
+	return []byte(s), nil
+}
+
+// writeEtcHosts is akin to writeResolvConf
+// TODO: dedupe
+func writeEtcHosts() error {
+	newEtcHosts, err := generateEtcHosts()
+	if err != nil {
+		return err
+	}
+	// remove copied-up link
+	_ = os.Remove("/etc/hosts")
+	if err := ioutil.WriteFile("/etc/hosts", newEtcHosts, 0644); err != nil {
+		return errors.Wrapf(err, "writing /etc/hosts")
+	}
+	return nil
+}
+
+// mountEtcHosts is akin to mountResolvConf
+// TODO: dedupe
+func mountEtcHosts(tempDir string) error {
+	newEtcHosts, err := generateEtcHosts()
+	if err != nil {
+		return err
+	}
+	myEtcHosts := filepath.Join(tempDir, "hosts")
+	if err := ioutil.WriteFile(myEtcHosts, newEtcHosts, 0644); err != nil {
+		return errors.Wrapf(err, "writing %s", myEtcHosts)
+	}
+	cmds := [][]string{
+		{"mount", "--bind", myEtcHosts, "/etc/hosts"},
+	}
+	if err := common.Execs(os.Stderr, os.Environ(), cmds); err != nil {
+		return errors.Wrapf(err, "executing %v", cmds)
+	}
+	return nil
+}


### PR DESCRIPTION
Without this fix, Usernetes does not work because the hostname
is resolved into the IP address of the eth0 in the host network namespace.

  $ ./kubectl.sh run -it --rm --image alpine foo
  If you don't see a command prompt, try pressing enter.
  Error attaching, falling back to logs: error dialing backend: dial tcp 10.138.0.2:10250: connect: connection refused
  deployment.apps "foo" deleted
  Error from server: Get https://oregon:10250/containerLogs/default/foo-68d78ff5c9-t97fr/foo: dial tcp 10.138.0.2:10250: connect: connection refused

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>