### PR TITLE
support specifying slirp4netns CIDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ USAGE:
    rootlesskit [global options] command [command options] [arguments...]
 
 VERSION:
-   0.0.0
+   0.2.0+dev
 
 COMMANDS:
      help, h  Shows a list of commands or help for one command
@@ -114,13 +114,13 @@ GLOBAL OPTIONS:
    --slirp4netns-binary value  path of slirp4netns binary for --net=slirp4netns (default: "slirp4netns")
    --vpnkit-binary value       path of VPNKit binary for --net=vpnkit (default: "vpnkit")
    --mtu value                 MTU for non-host network (default: 65520 for slirp4netns, 1500 for others) (default: 0)
+   --cidr value                CIDR for slirp4netns network (default: 10.0.2.0/24, requires slirp4netns v0.3.0+ for custom CIDR)
    --copy-up value             mount a filesystem and copy-up the contents. e.g. "--copy-up=/etc" (typically required for non-host network)
    --copy-up-mode value        copy-up mode [tmpfs+symlink] (default: "tmpfs+symlink")
    --port-driver value         port driver for non-host network. [none, socat] (default: "none")
    --help, -h                  show help
    --version, -v               print the version
 ```
-
 
 ## State directory
 
@@ -179,6 +179,7 @@ Default network configuration for `--net=vpnkit`:
 * DNS: 192.168.65.1
 * Host: 192.168.65.2
 
+`--net=slirp4netns` supports specifying custom CIDR, e.g. `--cidr=10.0.3.0/24` (requires slirp4netns v0.3.0+)
 
 ### Port forwarding
 

--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -58,6 +59,10 @@ func main() {
 			Name:  "mtu",
 			Usage: "MTU for non-host network (default: 65520 for slirp4netns, 1500 for others)",
 			Value: 0, // resolved into 65520 for slirp4netns, 1500 for others
+		},
+		cli.StringFlag{
+			Name:  "cidr",
+			Usage: "CIDR for slirp4netns network (default: 10.0.2.0/24, requires slirp4netns v0.3.0+ for custom CIDR)",
 		},
 		cli.StringSliceFlag{
 			Name:  "copy-up",
@@ -116,6 +121,20 @@ func main() {
 	}
 }
 
+func parseCIDR(s string) (*net.IPNet, error) {
+	if s == "" {
+		return nil, nil
+	}
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+	if !ip.Equal(ipnet.IP) {
+		return nil, errors.Errorf("cidr must be like 10.0.2.0/24, not like 10.0.2.100/24")
+	}
+	return ipnet, nil
+}
+
 func createParentOpt(clicontext *cli.Context) (*parent.Opt, error) {
 	opt := &parent.Opt{}
 	var err error
@@ -125,25 +144,39 @@ func createParentOpt(clicontext *cli.Context) (*parent.Opt, error) {
 		// 0 is ok (stands for the driver's default)
 		return nil, errors.Errorf("mtu must be <= 65521, got %d", mtu)
 	}
+	ipnet, err := parseCIDR(clicontext.String("cidr"))
+	if err != nil {
+		return nil, err
+	}
 	switch s := clicontext.String("net"); s {
 	case "host":
 		// NOP
 		if mtu != 0 {
 			logrus.Warnf("unsupported mtu for --net=host: %d", mtu)
 		}
+		if ipnet != nil {
+			return nil, errors.New("custom cidr is supported only for --net=slirp4netns (with slirp4netns v0.3.0+)")
+		}
 	case "slirp4netns":
 		binary := clicontext.String("slirp4netns-binary")
 		if _, err := exec.LookPath(binary); err != nil {
 			return nil, err
 		}
-		opt.NetworkDriver = slirp4netns.NewParentDriver(binary, mtu)
+		opt.NetworkDriver = slirp4netns.NewParentDriver(binary, mtu, ipnet)
 	case "vpnkit":
+		if ipnet != nil {
+			return nil, errors.New("custom cidr is supported only for --net=slirp4netns (with slirp4netns v0.3.0+)")
+		}
+
 		binary := clicontext.String("vpnkit-binary")
 		if _, err := exec.LookPath(binary); err != nil {
 			return nil, err
 		}
 		opt.NetworkDriver = vpnkit.NewParentDriver(binary, mtu)
 	case "vdeplug_slirp":
+		if ipnet != nil {
+			return nil, errors.New("custom cidr is supported only for --net=slirp4netns (with slirp4netns v0.3.0+)")
+		}
 		opt.NetworkDriver = vdeplugslirp.NewParentDriver(mtu)
 	default:
 		return nil, errors.Errorf("unknown network mode: %s", s)

--- a/hack/test/Dockerfile
+++ b/hack/test/Dockerfile
@@ -26,7 +26,7 @@ RUN ./autogen.sh --disable-nls --disable-man --without-audit --without-selinux -
 && cp src/newuidmap src/newgidmap /usr/bin
 
 FROM build-c AS slirp4netns
-ARG SLIRP4NETNS_COMMIT=39e87c0e66345edf7fd6e0bd1f61aa842617e757
+ARG SLIRP4NETNS_COMMIT=v0.3.0-alpha.0
 RUN git clone https://github.com/rootless-containers/slirp4netns.git /slirp4netns && \
   cd /slirp4netns && git checkout ${SLIRP4NETNS_COMMIT} && \
   ./autogen.sh && ./configure && make

--- a/pkg/network/iputils/iputils.go
+++ b/pkg/network/iputils/iputils.go
@@ -1,0 +1,24 @@
+package iputils
+
+import (
+	"encoding/binary"
+	"math"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+func AddIPInt(ip net.IP, i int) (net.IP, error) {
+	ip = ip.To4()
+	if ip == nil {
+		return nil, errors.Errorf("expected IPv4 address, got %s", ip.String())
+	}
+	ui32 := binary.BigEndian.Uint32(ip)
+	resInt := int(ui32) + i
+	if resInt > math.MaxUint32 {
+		return nil, errors.Errorf("%s + %d overflows", ip.String(), i)
+	}
+	res := make(net.IP, 4)
+	binary.BigEndian.PutUint32(res, uint32(resInt))
+	return res, nil
+}

--- a/pkg/network/iputils/iputils_test.go
+++ b/pkg/network/iputils/iputils_test.go
@@ -1,0 +1,51 @@
+package iputils
+
+import (
+	"net"
+	"testing"
+)
+
+func TestAddIPInt(t *testing.T) {
+	type testCase struct {
+		s        string
+		i        int
+		expected string
+	}
+	testCases := []testCase{
+		{
+			"10.0.2.0",
+			100,
+			"10.0.2.100",
+		},
+		{
+			"255.255.255.100",
+			155,
+			"255.255.255.255",
+		},
+		{
+			"255.255.255.100",
+			156,
+			"",
+		},
+	}
+	for i, tc := range testCases {
+		ip := net.ParseIP(tc.s)
+		if ip == nil {
+			t.Fatalf("invalid IP: %q", tc.s)
+		}
+		gotIP, err := AddIPInt(ip, tc.i)
+		if tc.expected == "" {
+			if err == nil {
+				t.Fatalf("#%d: expected error, got no error", i)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("#%d: expected no error, got %q", i, err)
+			}
+			got := gotIP.String()
+			if got != tc.expected {
+				t.Fatalf("#%d: expected %q, got %q", i, tc.expected, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Requires slirp4netns v0.3.0-alpha.0 or later

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>