### PR TITLE
 copyup/tmpfssymlink: delete target path before creating symlink (v0.3.0-alpha.2)

### DIFF
--- a/pkg/copyup/tmpfssymlink/tmpfssymlink.go
+++ b/pkg/copyup/tmpfssymlink/tmpfssymlink.go
@@ -67,6 +67,11 @@ func (d *childDriver) CopyUp(dirs []string) ([]string, error) {
 				symlinkSrc = filepath.Join(filepath.Base(bind1), f.Name())
 			}
 			symlinkDst := filepath.Join(d, f.Name())
+			// `mount` may create extra `/etc/mtab` after mounting empty tmpfs on /etc
+			// https://github.com/rootless-containers/rootlesskit/issues/45
+			if err = os.RemoveAll(symlinkDst); err != nil {
+				return copied, errors.Wrapf(err, "removing %s", symlinkDst)
+			}
 			if err := os.Symlink(symlinkSrc, symlinkDst); err != nil {
 				return copied, errors.Wrapf(err, "symlinking %s to %s", symlinkSrc, symlinkDst)
 			}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.3.0-alpha.1+dev"
+const Version = "0.3.0-alpha.2"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.3.0-alpha.2"
+const Version = "0.3.0-alpha.2+dev"


### PR DESCRIPTION
Fix #45 