### PR TITLE
move pcap from /tmp to XDG_RUNTIME_DIR

### DIFF
--- a/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
+++ b/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
@@ -563,7 +563,14 @@ func (v *Vif) dhcp() (net.IP, error) {
 	ethernet := NewEthernetFrame(broadcastMAC, v.ClientMAC, 0x800)
 	ethernet.setData(ipv4.Bytes())
 
-	runDir := os.Getenv("XDG_RUNTIME_DIR")
+	// getEnv ref: https://stackoverflow.com/a/40326580
+	getEnv := func (key, fallback string) string {
+		if value, ok := os.LookupEnv(key); ok {
+			return value
+		}
+		return fallback
+	}
+	runDir := getEnv("XDG_RUNTIME_DIR", "/tmp")
 	pcapPath := fmt.Sprintf("%s/go.pcap", runDir)
 	file, err := os.Create(pcapPath)
 	if err != nil {

--- a/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
+++ b/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
@@ -564,7 +564,7 @@ func (v *Vif) dhcp() (net.IP, error) {
 	ethernet.setData(ipv4.Bytes())
 
 	// getEnv ref: https://stackoverflow.com/a/40326580
-	getEnv := func (key, fallback string) string {
+	getEnv := func(key, fallback string) string {
 		if value, ok := os.LookupEnv(key); ok {
 			return value
 		}

--- a/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
+++ b/vendor/github.com/moby/vpnkit/go/pkg/vmnet/vmnet.go
@@ -563,7 +563,9 @@ func (v *Vif) dhcp() (net.IP, error) {
 	ethernet := NewEthernetFrame(broadcastMAC, v.ClientMAC, 0x800)
 	ethernet.setData(ipv4.Bytes())
 
-	file, err := os.Create("/tmp/go.pcap")
+	runDir := os.Getenv("XDG_RUNTIME_DIR")
+	pcapPath := fmt.Sprintf("%s/go.pcap", runDir)
+	file, err := os.Create(pcapPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When working with https://get.dockerless.com/rootless I found that only one user could run the docker service at a time.  The reason is that the first to write /tmp/go.pcap was the owner of that file, and because other users could not write it (because of they did not own it), they could not start docker.  With this PR, as long as the `XDG_RUNTIME_DIR` environment variable is set, multiple users can run rootless docker, because each user's instance writes go.pcap to the runtime directory that they own.

This PR is intended to provoke discussion - I don't mind if it is rejected, but I would like suggestions for how to proceed.  The code that I changed is in fact from the moby/vpnkit package (though copied into this repository) - how would you like to manage this, assuming that you like this change?