### PR TITLE
child: reconfigure Pdeathsig (release v0.4.1)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.4.0+dev"
+const Version = "0.4.1"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.4.1"
+const Version = "0.4.1+dev"


### PR DESCRIPTION
The parent calls child with Pdeathsig, but it is cleared when newuidmap SUID binary is called
https://github.com/rootless-containers/rootlesskit/issues/65#issuecomment-492343646

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>