### PR TITLE
rootlesskit: add -p for publishing ports (similar to `docker run -p`) (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ USAGE:
    rootlesskit [global options] command [command options] [arguments...]
 
 VERSION:
-   0.4.1+dev
+   0.5.0+dev
 
 COMMANDS:
      help, h  Shows a list of commands or help for one command
@@ -162,6 +162,7 @@ GLOBAL OPTIONS:
    --copy-up value              mount a filesystem and copy-up the contents. e.g. "--copy-up=/etc" (typically required for non-host network)
    --copy-up-mode value         copy-up mode [tmpfs+symlink] (default: "tmpfs+symlink")
    --port-driver value          port driver for non-host network. [none, socat, slirp4netns, builtin(experimental)] (default: "none")
+   --publish value, -p value    publish ports. e.g. "127.0.0.1:8080:80/tcp"
    --pidns                      create a PID namespace
    --help, -h                   show help
    --version, -v                print the version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.6.0"
+const Version = "0.6.0+dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.5.0+dev"
+const Version = "0.6.0"


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>