### PR TITLE
slirp4netns: --create-sandbox -> --enable-sandbox

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -239,23 +239,23 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey strin
 		if slirp4netnsAPISocketPath != "" && !features.SupportsAPISocket {
 			return opt, errors.New("unsupported slirp4netns version: lacks SupportsAPISocket, please install v0.3.0+")
 		}
-		createSandbox := false
+		enableSandbox := false
 		switch s := clicontext.String("slirp4netns-sandbox"); s {
 		case "auto":
 			// this might not work when /etc/resolv.conf is a symlink to a file outside /etc or /run
 			// https://github.com/rootless-containers/slirp4netns/issues/116
-			createSandbox = features.SupportsCreateSandbox
+			enableSandbox = features.SupportsEnableSandbox
 		case "true":
-			createSandbox = true
-			if !features.SupportsCreateSandbox {
-				return opt, errors.New("unsupported slirp4netns version: lacks SupportsCreateSandbox, please install v0.4.0+")
+			enableSandbox = true
+			if !features.SupportsEnableSandbox {
+				return opt, errors.New("unsupported slirp4netns version: lacks SupportsEnableSandbox, please install v0.4.0+")
 			}
 		case "false", "": // default
 			// NOP
 		default:
 			return opt, errors.Errorf("unsupported slirp4netns-sandbox mode: %q", s)
 		}
-		opt.NetworkDriver = slirp4netns.NewParentDriver(binary, mtu, ipnet, disableHostLoopback, slirp4netnsAPISocketPath, createSandbox)
+		opt.NetworkDriver = slirp4netns.NewParentDriver(binary, mtu, ipnet, disableHostLoopback, slirp4netnsAPISocketPath, enableSandbox)
 	case "vpnkit":
 		if ipnet != nil {
 			return opt, errors.New("custom cidr is supported only for --net=slirp4netns (with slirp4netns v0.3.0+)")

--- a/pkg/network/slirp4netns/slirp4netns.go
+++ b/pkg/network/slirp4netns/slirp4netns.go
@@ -25,8 +25,8 @@ type Features struct {
 	SupportsDisableHostLoopback bool
 	// SupportsAPISocket --api-socket (v0.3.0)
 	SupportsAPISocket bool
-	// SupportsCreateSandbox --create-sandbox (v0.4.0)
-	SupportsCreateSandbox bool
+	// SupportsEnableSandbox --enable-sandbox (v0.4.0)
+	SupportsEnableSandbox bool
 }
 
 func DetectFeatures(binary string) (*Features, error) {
@@ -50,7 +50,7 @@ func DetectFeatures(binary string) (*Features, error) {
 		SupportsCIDR:                strings.Contains(s, "--cidr"),
 		SupportsDisableHostLoopback: strings.Contains(s, "--disable-host-loopback"),
 		SupportsAPISocket:           strings.Contains(s, "--api-socket"),
-		SupportsCreateSandbox:       strings.Contains(s, "--create-sandbox"),
+		SupportsEnableSandbox:       strings.Contains(s, "--enable-sandbox"),
 	}
 	return &f, nil
 }
@@ -61,8 +61,8 @@ func DetectFeatures(binary string) (*Features, error) {
 //
 // disableHostLoopback is supported only for slirp4netns v0.3.0+
 // apiSocketPath is supported only for slirp4netns v0.3.0+
-// createSandbox is supported only for slirp4netns v0.4.0+
-func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopback bool, apiSocketPath string, createSandbox bool) network.ParentDriver {
+// enableSandbox is supported only for slirp4netns v0.4.0+
+func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopback bool, apiSocketPath string, enableSandbox bool) network.ParentDriver {
 	if binary == "" {
 		panic("got empty slirp4netns binary")
 	}
@@ -78,7 +78,7 @@ func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopba
 		ipnet:               ipnet,
 		disableHostLoopback: disableHostLoopback,
 		apiSocketPath:       apiSocketPath,
-		createSandbox:       createSandbox,
+		enableSandbox:       enableSandbox,
 	}
 }
 
@@ -88,7 +88,7 @@ type parentDriver struct {
 	ipnet               *net.IPNet
 	disableHostLoopback bool
 	apiSocketPath       string
-	createSandbox       bool
+	enableSandbox       bool
 }
 
 func (d *parentDriver) MTU() int {
@@ -112,8 +112,8 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir string) (*common.
 	if d.apiSocketPath != "" {
 		opts = append(opts, "--api-socket", d.apiSocketPath)
 	}
-	if d.createSandbox {
-		opts = append(opts, "--create-sandbox")
+	if d.enableSandbox {
+		opts = append(opts, "--enable-sandbox")
 	}
 	cmd := exec.CommandContext(ctx, d.binary, append(opts, []string{strconv.Itoa(childPID), tap}...)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
the flag was introduced in slirp4netns v0.4.0-beta.2 and then renamed in beta.4

https://github.com/rootless-containers/slirp4netns/pull/137

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>