### PR TITLE
v0.7.1

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.7.0+dev"
+const Version = "0.7.1"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.7.1"
+const Version = "0.7.1+dev"


### PR DESCRIPTION
Notable changes since v0.7.0:
* port: move `builtin` out of experimental; deprecate `socat` and `slirp4netns` (#85)
  (NOTE: `slirp4netns` *port* driver (ingress) is deprecated, but `slirp4netns` *network* driver (egress) is NOT deprecated.)
* port/builtin: Fix proxying UDP reply packets (#87)