### PR TITLE
Add reaper functionality to child

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -373,6 +373,7 @@ func createChildOpt(clicontext *cli.Context, pipeFDEnvKey string, targetCmd []st
 		PipeFDEnvKey: pipeFDEnvKey,
 		TargetCmd:    targetCmd,
 		MountProcfs:  clicontext.Bool("pidns"),
+		Reaper:       clicontext.Bool("pidns"),
 	}
 	switch s := clicontext.String("net"); s {
 	case "host":


### PR DESCRIPTION
A new field Reaper is added to child.Opts to run a process
reaper when running the child target command.  This is needed
if you are running the child in a new PID namespace and you wish
to avoid zombies.