### PR TITLE
new env var: $ROOTLESSKIT_PARENT_EUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Undocumented files are subject to change.
 
 The following environment variables will be set for the child process:
 * `ROOTLESSKIT_STATE_DIR` (since v0.3.0): absolute path to the state dir
+* `ROOTLESSKIT_PARENT_EUID` (since v0.8.0): effective UID
+* `ROOTLESSKIT_PARENT_EGID` (since v0.8.0): effective GID
 
 Undocumented environment variables are subject to change.
 

--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -31,8 +31,10 @@ import (
 
 func main() {
 	const (
-		pipeFDEnvKey   = "_ROOTLESSKIT_PIPEFD_UNDOCUMENTED"
-		stateDirEnvKey = "ROOTLESSKIT_STATE_DIR" // documented
+		pipeFDEnvKey     = "_ROOTLESSKIT_PIPEFD_UNDOCUMENTED"
+		stateDirEnvKey   = "ROOTLESSKIT_STATE_DIR"   // documented
+		parentEUIDEnvKey = "ROOTLESSKIT_PARENT_EUID" // documented
+		parentEGIDEnvKey = "ROOTLESSKIT_PARENT_EGID" // documented
 	)
 	iAmChild := os.Getenv(pipeFDEnvKey) != ""
 	debug := false
@@ -138,7 +140,8 @@ func main() {
 			}
 			return child.Child(childOpt)
 		}
-		parentOpt, err := createParentOpt(clicontext, pipeFDEnvKey, stateDirEnvKey)
+		parentOpt, err := createParentOpt(clicontext, pipeFDEnvKey, stateDirEnvKey,
+			parentEUIDEnvKey, parentEGIDEnvKey)
 		if err != nil {
 			return err
 		}
@@ -177,12 +180,14 @@ func parseCIDR(s string) (*net.IPNet, error) {
 	return ipnet, nil
 }
 
-func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey string) (parent.Opt, error) {
+func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, parentEUIDEnvKey, parentEGIDEnvKey string) (parent.Opt, error) {
 	var err error
 	opt := parent.Opt{
-		PipeFDEnvKey:   pipeFDEnvKey,
-		StateDirEnvKey: stateDirEnvKey,
-		CreatePIDNS:    clicontext.Bool("pidns"),
+		PipeFDEnvKey:     pipeFDEnvKey,
+		StateDirEnvKey:   stateDirEnvKey,
+		CreatePIDNS:      clicontext.Bool("pidns"),
+		ParentEUIDEnvKey: parentEUIDEnvKey,
+		ParentEGIDEnvKey: parentEGIDEnvKey,
 	}
 	opt.StateDir = clicontext.String("state-dir")
 	if opt.StateDir == "" {

--- a/pkg/parent/parent.go
+++ b/pkg/parent/parent.go
@@ -2,6 +2,7 @@ package parent
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -26,13 +27,15 @@ import (
 )
 
 type Opt struct {
-	PipeFDEnvKey   string               // needs to be set
-	StateDir       string               // directory needs to be precreated
-	StateDirEnvKey string               // optional env key to propagate StateDir value
-	NetworkDriver  network.ParentDriver // nil for HostNetwork
-	PortDriver     port.ParentDriver    // nil for --port-driver=none
-	PublishPorts   []port.Spec
-	CreatePIDNS    bool
+	PipeFDEnvKey     string               // needs to be set
+	StateDir         string               // directory needs to be precreated
+	StateDirEnvKey   string               // optional env key to propagate StateDir value
+	NetworkDriver    network.ParentDriver // nil for HostNetwork
+	PortDriver       port.ParentDriver    // nil for --port-driver=none
+	PublishPorts     []port.Spec
+	CreatePIDNS      bool
+	ParentEUIDEnvKey string // optional env key to propagate geteuid() value
+	ParentEGIDEnvKey string // optional env key to propagate getegid() value
 }
 
 // Documented state files. Undocumented ones are subject to change.
@@ -99,6 +102,12 @@ func Parent(opt Opt) error {
 	cmd.Env = append(os.Environ(), opt.PipeFDEnvKey+"=3")
 	if opt.StateDirEnvKey != "" {
 		cmd.Env = append(cmd.Env, opt.StateDirEnvKey+"="+opt.StateDir)
+	}
+	if opt.ParentEUIDEnvKey != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", opt.ParentEUIDEnvKey, os.Geteuid()))
+	}
+	if opt.ParentEGIDEnvKey != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%d", opt.ParentEGIDEnvKey, os.Getegid()))
 	}
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "failed to start the child")


### PR DESCRIPTION
The parent EUID is propagated into the child via $ROOTLESSKIT_PARENT_EUID .
