### PR TITLE
v0.9.0-beta.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.8.0+dev"
+const Version = "0.9.0-beta.0"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.9.0-beta.0"
+const Version = "0.9.0-beta.0+dev"


### PR DESCRIPTION
Notable changes since v0.8.0:
* Support `--propagation=(rprivate|rslave)`. The default value remains `rprivate`, but `rslave` is more useful in most cases. `rshared` doesn't work with `--copy-up` and isn't useful. (#109)
* Removed support for `--net=vdeplug_slirp`. `vdeplug_slirp` has been already deprecated since v0.4.0. (#113)