### PR TITLE
support forwarding signals

### DIFF
--- a/pkg/parent/parent.go
+++ b/pkg/parent/parent.go
@@ -24,6 +24,8 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/network"
 	"github.com/rootless-containers/rootlesskit/pkg/parent/idtools"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
+	"github.com/rootless-containers/rootlesskit/pkg/sigproxy"
+	"github.com/rootless-containers/rootlesskit/pkg/sigproxy/signal"
 )
 
 type Opt struct {
@@ -131,6 +133,9 @@ func Parent(opt Opt) error {
 	if err := setupUIDGIDMap(cmd.Process.Pid); err != nil {
 		return errors.Wrap(err, "failed to setup UID/GID map")
 	}
+	sigc := sigproxy.ForwardAllSignals(context.TODO(), cmd.Process.Pid)
+	defer signal.StopCatch(sigc)
+
 	// send message 0
 	msg := common.Message{
 		Stage:    0,

--- a/pkg/sigproxy/signal/signal.go
+++ b/pkg/sigproxy/signal/signal.go
@@ -1,0 +1,25 @@
+// Package signal provides helper functions for dealing with signals across
+// various operating systems.
+//
+// Forked from https://github.com/moby/moby/tree/37defbfd9b968f38e8e15dfa5f06d9f878bd65ba/pkg/signal
+package signal
+
+import (
+	"os"
+	"os/signal"
+)
+
+// CatchAll catches all signals and relays them to the specified channel.
+func CatchAll(sigc chan os.Signal) {
+	var handledSigs []os.Signal
+	for _, s := range SignalMap {
+		handledSigs = append(handledSigs, s)
+	}
+	signal.Notify(sigc, handledSigs...)
+}
+
+// StopCatch stops catching the signals and closes the specified channel.
+func StopCatch(sigc chan os.Signal) {
+	signal.Stop(sigc)
+	close(sigc)
+}

--- a/pkg/sigproxy/signal/signal_linux.go
+++ b/pkg/sigproxy/signal/signal_linux.go
@@ -1,0 +1,83 @@
+// +build !mips,!mipsle,!mips64,!mips64le
+
+package signal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sigrtmin = 34
+	sigrtmax = 64
+)
+
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":     unix.SIGABRT,
+	"ALRM":     unix.SIGALRM,
+	"BUS":      unix.SIGBUS,
+	"CHLD":     unix.SIGCHLD,
+	"CLD":      unix.SIGCLD,
+	"CONT":     unix.SIGCONT,
+	"FPE":      unix.SIGFPE,
+	"HUP":      unix.SIGHUP,
+	"ILL":      unix.SIGILL,
+	"INT":      unix.SIGINT,
+	"IO":       unix.SIGIO,
+	"IOT":      unix.SIGIOT,
+	"KILL":     unix.SIGKILL,
+	"PIPE":     unix.SIGPIPE,
+	"POLL":     unix.SIGPOLL,
+	"PROF":     unix.SIGPROF,
+	"PWR":      unix.SIGPWR,
+	"QUIT":     unix.SIGQUIT,
+	"SEGV":     unix.SIGSEGV,
+	"STKFLT":   unix.SIGSTKFLT,
+	"STOP":     unix.SIGSTOP,
+	"SYS":      unix.SIGSYS,
+	"TERM":     unix.SIGTERM,
+	"TRAP":     unix.SIGTRAP,
+	"TSTP":     unix.SIGTSTP,
+	"TTIN":     unix.SIGTTIN,
+	"TTOU":     unix.SIGTTOU,
+	"URG":      unix.SIGURG,
+	"USR1":     unix.SIGUSR1,
+	"USR2":     unix.SIGUSR2,
+	"VTALRM":   unix.SIGVTALRM,
+	"WINCH":    unix.SIGWINCH,
+	"XCPU":     unix.SIGXCPU,
+	"XFSZ":     unix.SIGXFSZ,
+	"RTMIN":    sigrtmin,
+	"RTMIN+1":  sigrtmin + 1,
+	"RTMIN+2":  sigrtmin + 2,
+	"RTMIN+3":  sigrtmin + 3,
+	"RTMIN+4":  sigrtmin + 4,
+	"RTMIN+5":  sigrtmin + 5,
+	"RTMIN+6":  sigrtmin + 6,
+	"RTMIN+7":  sigrtmin + 7,
+	"RTMIN+8":  sigrtmin + 8,
+	"RTMIN+9":  sigrtmin + 9,
+	"RTMIN+10": sigrtmin + 10,
+	"RTMIN+11": sigrtmin + 11,
+	"RTMIN+12": sigrtmin + 12,
+	"RTMIN+13": sigrtmin + 13,
+	"RTMIN+14": sigrtmin + 14,
+	"RTMIN+15": sigrtmin + 15,
+	"RTMAX-14": sigrtmax - 14,
+	"RTMAX-13": sigrtmax - 13,
+	"RTMAX-12": sigrtmax - 12,
+	"RTMAX-11": sigrtmax - 11,
+	"RTMAX-10": sigrtmax - 10,
+	"RTMAX-9":  sigrtmax - 9,
+	"RTMAX-8":  sigrtmax - 8,
+	"RTMAX-7":  sigrtmax - 7,
+	"RTMAX-6":  sigrtmax - 6,
+	"RTMAX-5":  sigrtmax - 5,
+	"RTMAX-4":  sigrtmax - 4,
+	"RTMAX-3":  sigrtmax - 3,
+	"RTMAX-2":  sigrtmax - 2,
+	"RTMAX-1":  sigrtmax - 1,
+	"RTMAX":    sigrtmax,
+}

--- a/pkg/sigproxy/signal/signal_linux_mipsx.go
+++ b/pkg/sigproxy/signal/signal_linux_mipsx.go
@@ -1,0 +1,84 @@
+// +build linux
+// +build mips mipsle mips64 mips64le
+
+package signal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sigrtmin = 34
+	sigrtmax = 127
+)
+
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":     unix.SIGABRT,
+	"ALRM":     unix.SIGALRM,
+	"BUS":      unix.SIGBUS,
+	"CHLD":     unix.SIGCHLD,
+	"CLD":      unix.SIGCLD,
+	"CONT":     unix.SIGCONT,
+	"FPE":      unix.SIGFPE,
+	"HUP":      unix.SIGHUP,
+	"ILL":      unix.SIGILL,
+	"INT":      unix.SIGINT,
+	"IO":       unix.SIGIO,
+	"IOT":      unix.SIGIOT,
+	"KILL":     unix.SIGKILL,
+	"PIPE":     unix.SIGPIPE,
+	"POLL":     unix.SIGPOLL,
+	"PROF":     unix.SIGPROF,
+	"PWR":      unix.SIGPWR,
+	"QUIT":     unix.SIGQUIT,
+	"SEGV":     unix.SIGSEGV,
+	"EMT":      unix.SIGEMT,
+	"STOP":     unix.SIGSTOP,
+	"SYS":      unix.SIGSYS,
+	"TERM":     unix.SIGTERM,
+	"TRAP":     unix.SIGTRAP,
+	"TSTP":     unix.SIGTSTP,
+	"TTIN":     unix.SIGTTIN,
+	"TTOU":     unix.SIGTTOU,
+	"URG":      unix.SIGURG,
+	"USR1":     unix.SIGUSR1,
+	"USR2":     unix.SIGUSR2,
+	"VTALRM":   unix.SIGVTALRM,
+	"WINCH":    unix.SIGWINCH,
+	"XCPU":     unix.SIGXCPU,
+	"XFSZ":     unix.SIGXFSZ,
+	"RTMIN":    sigrtmin,
+	"RTMIN+1":  sigrtmin + 1,
+	"RTMIN+2":  sigrtmin + 2,
+	"RTMIN+3":  sigrtmin + 3,
+	"RTMIN+4":  sigrtmin + 4,
+	"RTMIN+5":  sigrtmin + 5,
+	"RTMIN+6":  sigrtmin + 6,
+	"RTMIN+7":  sigrtmin + 7,
+	"RTMIN+8":  sigrtmin + 8,
+	"RTMIN+9":  sigrtmin + 9,
+	"RTMIN+10": sigrtmin + 10,
+	"RTMIN+11": sigrtmin + 11,
+	"RTMIN+12": sigrtmin + 12,
+	"RTMIN+13": sigrtmin + 13,
+	"RTMIN+14": sigrtmin + 14,
+	"RTMIN+15": sigrtmin + 15,
+	"RTMAX-14": sigrtmax - 14,
+	"RTMAX-13": sigrtmax - 13,
+	"RTMAX-12": sigrtmax - 12,
+	"RTMAX-11": sigrtmax - 11,
+	"RTMAX-10": sigrtmax - 10,
+	"RTMAX-9":  sigrtmax - 9,
+	"RTMAX-8":  sigrtmax - 8,
+	"RTMAX-7":  sigrtmax - 7,
+	"RTMAX-6":  sigrtmax - 6,
+	"RTMAX-5":  sigrtmax - 5,
+	"RTMAX-4":  sigrtmax - 4,
+	"RTMAX-3":  sigrtmax - 3,
+	"RTMAX-2":  sigrtmax - 2,
+	"RTMAX-1":  sigrtmax - 1,
+	"RTMAX":    sigrtmax,
+}

--- a/pkg/sigproxy/sigproxy.go
+++ b/pkg/sigproxy/sigproxy.go
@@ -1,0 +1,34 @@
+package sigproxy
+
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/rootless-containers/rootlesskit/pkg/sigproxy/signal"
+)
+
+// ForwardAllSignals forwards signals.
+// Based on https://github.com/docker/cli/blob/ef2f64abbd37edfa148f745fa0013731b5074d1b/cli/command/container/tty.go#L99-L126
+func ForwardAllSignals(ctx context.Context, pid int) chan os.Signal {
+	sigc := make(chan os.Signal, 128)
+	signal.CatchAll(sigc)
+	go func() {
+		for s := range sigc {
+			if s == unix.SIGCHLD || s == unix.SIGPIPE || s == unix.SIGURG {
+				continue
+			}
+			us, ok := s.(unix.Signal)
+			if !ok {
+				logrus.Warnf("Unsupported signal %v", s)
+				continue
+			}
+			if err := unix.Kill(pid, us); err != nil {
+				logrus.WithError(err).Debugf("Error sending signal %v", s)
+			}
+		}
+	}()
+	return sigc
+}


### PR DESCRIPTION
Before:
```console
$ dockerd-rootless.sh --experimental
...
INFO[2020-03-15T11:02:16.526051714+09:00] API listen on /run/user/1001/docker.sock     
^C
$ echo $?
130
```

After:
```console
$ dockerd-rootless.sh --experimental
...
INFO[2020-03-15T11:02:42.263959577+09:00] API listen on /run/user/1001/docker.sock     
^CINFO[2020-03-15T11:02:43.493624366+09:00] Processing signal 'interrupt'                
INFO[2020-03-15T11:02:43.494655209+09:00] Processing signal 'interrupt'                
INFO[2020-03-15T11:02:43.495386457+09:00] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
INFO[2020-03-15T11:02:43.495546067+09:00] Daemon shutdown complete                     
INFO[2020-03-15T11:02:43.495566660+09:00] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
INFO[2020-03-15T11:02:43.495587614+09:00] stopping healthcheck following graceful shutdown  module=libcontainerd
INFO[2020-03-15T11:02:43.495986508+09:00] Processing signal 'interrupt'
$ echo $?
0
```

The implementation is based on https://github.com/docker/cli/blob/ef2f64abbd37edfa148f745fa0013731b5074d1b/cli/command/container/tty.go#L99-L12