### PR TITLE
rootlesskit-docker-proxy: report detailed error via FD 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The purpose of RootlessKit is to run [Docker and Kubernetes as an unprivileged u
   - [`--net=vpnkit`](#--netvpnkit)
   - [`--net=lxc-user-nic` (experimental)](#--netlxc-user-nic-experimental)
 - [Port Drivers](#port-drivers)
+  - [Exposing privileged ports](#exposing-privileged-ports)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -460,3 +461,11 @@ $ pid=$(cat /run/user/1001/rootlesskit/foo/child_pid)
 $ socat -t -- TCP-LISTEN:8080,reuseaddr,fork EXEC:"nsenter -U -n -t $pid socat -t -- STDIN TCP4\:127.0.0.1\:80"
 ```
 
+### Exposing privileged ports
+To expose privileged ports (< 1024), add `net.ipv4.ip_unprivileged_port_start=0` to `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl --system`.
+
+If you are using `builtin` driver, you can expose the privileged ports without changing the sysctl value, but you need to set `CAP_NET_BIND_SERVICE` on `rootlesskit` binary.
+
+```console
+$ sudo setcap cap_net_bind_service=ep $(pwd rootlesskit)
+```

--- a/cmd/rootlesskit-docker-proxy/main.go
+++ b/cmd/rootlesskit-docker-proxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/rootless-containers/rootlesskit/pkg/api/client"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -22,6 +25,17 @@ const (
 // drop-in replacement for docker-proxy.
 // needs to be executed in the child namespace.
 func main() {
+	f := os.NewFile(3, "signal-parent")
+	defer f.Close()
+	if err := xmain(f); err != nil {
+		// success: "0\n" (written by realProxy)
+		// error: "1\n" (written by either rootlesskit-docker-proxy or realProxy)
+		fmt.Fprintf(f, "1\n%s", err)
+		log.Fatal(err)
+	}
+}
+
+func xmain(f *os.File) error {
 	containerIP := flag.String("container-ip", "", "container ip")
 	containerPort := flag.Int("container-port", -1, "container port")
 	hostIP := flag.String("host-ip", "", "host ip")
@@ -29,30 +43,14 @@ func main() {
 	proto := flag.String("proto", "tcp", "proxy protocol")
 	flag.Parse()
 
-	cmd := exec.Command(realProxy,
-		"-container-ip", *containerIP,
-		"-container-port", strconv.Itoa(*containerPort),
-		"-host-ip", "127.0.0.1",
-		"-host-port", strconv.Itoa(*hostPort),
-		"-proto", *proto)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
-	if err := cmd.Start(); err != nil {
-		log.Fatal(err)
-	}
-
 	stateDir := os.Getenv("ROOTLESSKIT_STATE_DIR")
 	if stateDir == "" {
-		log.Fatalf("$ROOTLESSKIT_STATE_DIR needs to be set")
+		return errors.New("$ROOTLESSKIT_STATE_DIR needs to be set")
 	}
 	socketPath := filepath.Join(stateDir, "api.sock")
 	c, err := client.New(socketPath)
 	if err != nil {
-		log.Fatal(err)
+		return errors.Wrap(err, "error while connecting to RootlessKit API socket")
 	}
 	pm := c.PortManager()
 	p := port.Spec{
@@ -63,14 +61,32 @@ func main() {
 	}
 	st, err := pm.AddPort(context.Background(), p)
 	if err != nil {
-		log.Fatal(err)
+		return errors.Wrap(err, "error while calling PortManager.AddPort()")
 	}
 	defer pm.RemovePort(context.Background(), st.ID)
+
+	cmd := exec.Command(realProxy,
+		"-container-ip", *containerIP,
+		"-container-port", strconv.Itoa(*containerPort),
+		"-host-ip", "127.0.0.1",
+		"-host-port", strconv.Itoa(*hostPort),
+		"-proto", *proto)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	cmd.ExtraFiles = append(cmd.ExtraFiles, f)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+	if err := cmd.Start(); err != nil {
+		return errors.Wrapf(err, "error while starting %s", realProxy)
+	}
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt)
 	<-ch
 	if err := cmd.Process.Kill(); err != nil {
-		log.Fatal(err)
+		return errors.Wrapf(err, "error while killing %s", realProxy)
 	}
+	return nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,6 @@
+package api
+
+// ErrorJSON is returned with "application/json" content type and non-2XX status code
+type ErrorJSON struct {
+	Message string `json:"message"`
+}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 )
 
@@ -22,10 +23,7 @@ func (b *Backend) onError(w http.ResponseWriter, r *http.Request, err error, ec 
 	w.WriteHeader(ec)
 	w.Header().Set("Content-Type", "application/json")
 	// it is safe to return the err to the client, because the client is reliable
-	type errorJSON struct {
-		Message string `json:"message"`
-	}
-	e := errorJSON{
+	e := api.ErrorJSON{
 		Message: err.Error(),
 	}
 	_ = json.NewEncoder(w).Encode(e)

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -2,11 +2,14 @@ package parent
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -84,6 +87,39 @@ func (d *driver) RunParentDriver(initComplete chan struct{}, quit <-chan struct{
 	return nil
 }
 
+func isEPERM(err error) bool {
+	k := "permission denied"
+	// As of Go 1.14, errors.Is(err, syscall.EPERM) does not seem to work for
+	// "listen tcp 0.0.0.0:80: bind: permission denied" error from net.ListenTCP().
+	return errors.Is(err, syscall.EPERM) || strings.Contains(err.Error(), k)
+}
+
+// annotateEPERM annotates origErr for human-readability
+func annotateEPERM(origErr error, spec port.Spec) error {
+	// Read "net.ipv4.ip_unprivileged_port_start" value (typically 1024)
+	// TODO: what for IPv6?
+	// NOTE: sync.Once should not be used here
+	b, e := ioutil.ReadFile("/proc/sys/net/ipv4/ip_unprivileged_port_start")
+	if e != nil {
+		return origErr
+	}
+	start, e := strconv.Atoi(strings.TrimSpace(string(b)))
+	if e != nil {
+		return origErr
+	}
+	if spec.ParentPort >= start {
+		// origErr is unrelated to ip_unprivileged_port_start
+		return origErr
+	}
+	text := fmt.Sprintf("cannot expose privileged port %d, you might need to add \"net.ipv4.ip_unprivileged_port_start=0\" (currently %d) to /etc/sysctl.conf", spec.ParentPort, start)
+	if filepath.Base(os.Args[0]) == "rootlesskit" {
+		// NOTE: The following sentence is appended only if Args[0] == "rootlesskit", because it does not apply to Podman (as of Podman v1.9).
+		// Podman launches the parent driver in the child user namespace (but in the parent network namespace), which disables the file capability.
+		text += ", or set CAP_NET_BIND_SERVICE on rootlesskit binary"
+	}
+	return errors.Wrap(origErr, text)
+}
+
 func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, error) {
 	d.mu.Lock()
 	err := portutil.ValidatePortSpec(spec, d.ports)
@@ -106,6 +142,9 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 		return nil, errors.New("spec was not validated?")
 	}
 	if err != nil {
+		if isEPERM(err) {
+			err = annotateEPERM(err, spec)
+		}
 		return nil, err
 	}
 	d.mu.Lock()


### PR DESCRIPTION
Fix #135

---

Before:
```console
$ docker --context=rootless run -it -p 80:80 --rm alpine
docker: Error response from daemon: driver failed programming external connectiv
ity on endpoint clever_euclid (77c992ce4056362ee89727f4d2d96c349bbb9013b14f4f201
2412f2fbc94718e): Error starting userland proxy:.
```

After:
```console
$ docker --context=rootless run -it -p 80:80 --rm alpine
docker: Error response from daemon: driver failed programming external connectiv
ity on endpoint brave_murdock (71e0f00b4a8555cefd15d984d15f4dc255e4caa2ca5cc72df
8a04e463afc13b2): Error starting userland proxy: error while calling PortManager
.AddPort(): cannot expose privileged port 80, you might need to add "net.ipv4.ip
_unprivileged_port_start=0" (currently 1024) to /etc/sysctl.conf, or set CAP_NET
_BIND_SERVICE on rootlesskit binary: listen tcp 0.0.0.0:80: bind: permission den
ied.
```