### PR TITLE
Officially drop support for slirp4netns v0.3.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,7 @@ Cons:
 * Supports only TCP, UDP, and ICMP Echo packets
 
 
-To use `--net=slirp4netns`, you need to install slirp4netns.
-v0.3.0 or later is recommended.
+To use `--net=slirp4netns`, you need to install slirp4netns v0.4.0 or later.
 
 ```console
 $ sudo dnf install slirp4netns

--- a/pkg/network/slirp4netns/slirp4netns.go
+++ b/pkg/network/slirp4netns/slirp4netns.go
@@ -49,8 +49,13 @@ func DetectFeatures(binary string) (*Features, error) {
 	s := string(b)
 	if err != nil {
 		return nil, errors.Wrapf(err,
-			"command \"%s --help\" failed, make sure slirp4netns v0.2.0+ is installed: %q",
+			"command \"%s --help\" failed, make sure slirp4netns v0.4.0+ is installed: %q",
 			realBinary, s)
+	}
+	if !strings.Contains(s, "--netns-type") {
+		// We don't use --netns-type, but we check the presence of --netns-type to
+		// ensure slirp4netns >= v0.4.0: https://github.com/rootless-containers/rootlesskit/issues/143
+		return nil, errors.New("slirp4netns seems older than v0.4.0")
 	}
 	kernelSupportsEnableSeccomp := false
 	if unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0) != unix.EINVAL {
@@ -68,23 +73,40 @@ func DetectFeatures(binary string) (*Features, error) {
 }
 
 // NewParentDriver instantiates new parent driver.
-// ipnet is supported only for slirp4netns v0.3.0+.
-// ipnet MUST be nil for slirp4netns < v0.3.0.
-//
-// disableHostLoopback is supported only for slirp4netns v0.3.0+
-// apiSocketPath is supported only for slirp4netns v0.3.0+
-// enableSandbox is supported only for slirp4netns v0.4.0+
-// enableSeccomp is supported only for slirp4netns v0.4.0+
-func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopback bool, apiSocketPath string, enableSandbox, enableSeccomp bool) network.ParentDriver {
+// Requires slirp4netns v0.4.0 or later.
+func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopback bool, apiSocketPath string, enableSandbox, enableSeccomp bool) (network.ParentDriver, error) {
 	if binary == "" {
-		panic("got empty slirp4netns binary")
+		return nil, errors.New("got empty slirp4netns binary")
 	}
 	if mtu < 0 {
-		panic("got negative mtu")
+		return nil, errors.New("got negative mtu")
 	}
 	if mtu == 0 {
 		mtu = 65520
 	}
+	features, err := DetectFeatures(binary)
+	if err != nil {
+		return nil, err
+	}
+	if ipnet != nil && !features.SupportsCIDR {
+		return nil, errors.New("this version of slirp4netns does not support --cidr")
+	}
+	if disableHostLoopback && !features.SupportsDisableHostLoopback {
+		return nil, errors.New("this version of slirp4netns does not support --disable-host-loopback")
+	}
+	if apiSocketPath != "" && !features.SupportsAPISocket {
+		return nil, errors.New("this version of slirp4netns does not support --api-socket")
+	}
+	if enableSandbox && !features.SupportsEnableSandbox {
+		return nil, errors.New("this version of slirp4netns does not support --enable-sandbox")
+	}
+	if enableSeccomp && !features.SupportsEnableSeccomp {
+		return nil, errors.New("this version of slirp4netns does not support --enable-seccomp")
+	}
+	if enableSeccomp && !features.KernelSupportsEnableSeccomp {
+		return nil, errors.New("kernel does not support seccomp")
+	}
+
 	return &parentDriver{
 		binary:              binary,
 		mtu:                 mtu,
@@ -93,7 +115,7 @@ func NewParentDriver(binary string, mtu int, ipnet *net.IPNet, disableHostLoopba
 		apiSocketPath:       apiSocketPath,
 		enableSandbox:       enableSandbox,
 		enableSeccomp:       enableSeccomp,
-	}
+	}, nil
 }
 
 type parentDriver struct {
@@ -123,7 +145,7 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir string) (*common.
 	}
 	defer readyR.Close()
 	defer readyW.Close()
-	// -r: readyFD
+	// -r: readyFD (requires slirp4netns >= v0.4.0: https://github.com/rootless-containers/rootlesskit/issues/143)
 	opts := []string{"--mtu", strconv.Itoa(d.mtu), "-r", "3"}
 	if d.disableHostLoopback {
 		opts = append(opts, "--disable-host-loopback")


### PR DESCRIPTION
Support for slirp4netns v0.3.X has been broken since RootlessKit v0.7.1.
Also, slirp4netns v0.3.X has reached EOL on Mar 31, 2020.

Fix https://github.com/rootless-containers/rootlesskit/issues/143
