### PR TITLE
Lock StateDir

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -222,7 +222,6 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, pare
 	opt := parent.Opt{
 		PipeFDEnvKey:     pipeFDEnvKey,
 		StateDirEnvKey:   stateDirEnvKey,
-		StateDirTemp:     false,
 		CreatePIDNS:      clicontext.Bool("pidns"),
 		CreateCgroupNS:   clicontext.Bool("cgroupns"),
 		CreateUTSNS:      clicontext.Bool("utsns"),
@@ -237,7 +236,6 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, pare
 		if err != nil {
 			return opt, errors.Wrap(err, "creating a state directory")
 		}
-		opt.StateDirTemp = true
 	} else {
 		opt.StateDir, err = filepath.Abs(opt.StateDir)
 		if err != nil {

--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -222,6 +222,7 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, pare
 	opt := parent.Opt{
 		PipeFDEnvKey:     pipeFDEnvKey,
 		StateDirEnvKey:   stateDirEnvKey,
+		StateDirTemp:     false,
 		CreatePIDNS:      clicontext.Bool("pidns"),
 		CreateCgroupNS:   clicontext.Bool("cgroupns"),
 		CreateUTSNS:      clicontext.Bool("utsns"),
@@ -236,6 +237,7 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, pare
 		if err != nil {
 			return opt, errors.Wrap(err, "creating a state directory")
 		}
+		opt.StateDirTemp = true
 	} else {
 		opt.StateDir, err = filepath.Abs(opt.StateDir)
 		if err != nil {

--- a/pkg/parent/parent_test.go
+++ b/pkg/parent/parent_test.go
@@ -15,7 +15,7 @@ func TestBSDLockFileCreated(t *testing.T) {
 		t.Fatalf("expected no error, got %q", err)
 	}
 
-	err = createCleanupLock(tmpDir, true)
+	err = createCleanupLock(tmpDir)
 	if err != nil {
 		t.Fatalf("expected no error, got %q", err)
 	}
@@ -23,25 +23,6 @@ func TestBSDLockFileCreated(t *testing.T) {
 	stateDir, _ := os.Open(tmpDir)
 	err = unix.Flock(int(stateDir.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 	if err == nil {
-		t.Fatal("expected that ther was an error because of existing LOCK_SH")
-	}
-}
-func TestBSDLockFileNotCreated(t *testing.T) {
-
-	tmpDir, err := ioutil.TempDir("", "rootlesskit")
-	if err != nil {
-		t.Fatalf("expected no error, got %q", err)
-	}
-
-	err = createCleanupLock(tmpDir, false)
-	if err != nil {
-		t.Fatalf("expected no error, got %q", err)
-	}
-
-	//validate that no lock was written by set a lock on dir manually
-	stateDir, _ := os.Open(tmpDir)
-	err = unix.Flock(int(stateDir.Fd()), unix.LOCK_EX|unix.LOCK_NB)
-	if err != nil {
-		t.Fatalf("expected no error, got %q", err)
+		t.Fatal("expected that there was an error because of existing LOCK_SH")
 	}
 }

--- a/pkg/parent/parent_test.go
+++ b/pkg/parent/parent_test.go
@@ -1,0 +1,47 @@
+package parent
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestBSDLockFileCreated(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "rootlesskit")
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+
+	err = createCleanupLock(tmpDir, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+
+	stateDir, _ := os.Open(tmpDir)
+	err = unix.Flock(int(stateDir.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		t.Fatal("expected that ther was an error because of existing LOCK_SH")
+	}
+}
+func TestBSDLockFileNotCreated(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "rootlesskit")
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+
+	err = createCleanupLock(tmpDir, false)
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+
+	//validate that no lock was written by set a lock on dir manually
+	stateDir, _ := os.Open(tmpDir)
+	err = unix.Flock(int(stateDir.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+}


### PR DESCRIPTION
Hi all,

here is the FIX for the created issue #185 

## Description

If the user don't pass the `--state-dir` argument the internal `StateDirTemp` flag will be set.
On running the `Parent` function a Shared BSD Lock  [LOCK_SH](https://man7.org/linux/man-pages/man2/flock.2.html) will be set on the stateDir.

All locks will be removed with the `Rootlesskit` `StateFileLock` (`/tmp/rootlesskitXXX/lock`).

I also added a test to check if the lock was created, but to test that on a real system you have to read the verify part.

## Verify Systemd-tmpfiles cleanup resilience 

OS:  Ubuntu 18.04 LTS

1. Check tmp settings
`cat /usr/lib/tmpfiles.d/tmp.conf`

2. Change them if no cleanup for "old files" was configured.
`sudo nano /usr/lib/tmpfiles.d/tmp.conf`
See possible configuration settings: [tmpfiles.d(5)](https://man7.org/linux/man-pages/man5/tmpfiles.d.5.html)
**Example:** (for testing):
```D /tmp 1777 root root 10s -```
**Now all files will be deleted that are older than 10sec.**

3. Run systemd-tmpfiles cleanup manually 
To see whats happen we run the job with debug logs
`sudo env SYSTEMD_LOG_LEVEL=debug systemd-tmpfiles --clean` 

4. Check stateDir
The `rootlessXXX` stateDir in `/tmp/` still exists.

5. Show Lock
`lsof /tmp/rotlesskitXXXX`

 
Bg 
Tobi