### PR TITLE
port: add SetChildIP

### DIFF
--- a/pkg/port/builtin/child/child.go
+++ b/pkg/port/builtin/child/child.go
@@ -23,6 +23,7 @@ func NewDriver(logWriter io.Writer) port.ChildDriver {
 
 type childDriver struct {
 	logWriter io.Writer
+	childIP   string
 }
 
 func (d *childDriver) RunChildDriver(opaque map[string]string, quit <-chan struct{}) error {
@@ -38,6 +39,7 @@ func (d *childDriver) RunChildDriver(opaque map[string]string, quit <-chan struc
 	if err != nil {
 		return err
 	}
+	d.childIP = opaque[opaquepkg.ChildIP]
 	ln, err := net.ListenUnix("unix", &net.UnixAddr{
 		Name: socketPath,
 		Net:  "unix",
@@ -106,7 +108,7 @@ func (d *childDriver) handleConnectRequest(c *net.UnixConn, req *msg.Request) er
 		return errors.Errorf("unknown proto: %q", req.Proto)
 	}
 	var dialer net.Dialer
-	targetConn, err := dialer.Dial(req.Proto, fmt.Sprintf("127.0.0.1:%d", req.Port))
+	targetConn, err := dialer.Dial(req.Proto, fmt.Sprintf("%s:%d", d.childIP, req.Port))
 	if err != nil {
 		return err
 	}

--- a/pkg/port/builtin/opaque/opaque.go
+++ b/pkg/port/builtin/opaque/opaque.go
@@ -3,4 +3,5 @@ package opaque
 const (
 	SocketPath         = "builtin.socketpath"
 	ChildReadyPipePath = "builtin.readypipepath"
+	ChildIP            = "builtin.childip"
 )

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -42,6 +42,7 @@ func NewDriver(logWriter io.Writer, stateDir string) (port.ParentDriver, error) 
 		ports:              make(map[int]*port.Status, 0),
 		stoppers:           make(map[int]func() error, 0),
 		nextID:             1,
+		childIP:            "127.0.0.1",
 	}
 	return &d, nil
 }
@@ -54,12 +55,19 @@ type driver struct {
 	ports              map[int]*port.Status
 	stoppers           map[int]func() error
 	nextID             int
+	childIP            string
+}
+
+func (d *driver) SetChildIP(ip string) error {
+	d.childIP = ip
+	return nil
 }
 
 func (d *driver) OpaqueForChild() map[string]string {
 	return map[string]string{
 		opaque.SocketPath:         d.socketPath,
 		opaque.ChildReadyPipePath: d.childReadyPipePath,
+		opaque.ChildIP:            d.childIP,
 	}
 }
 

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -9,6 +9,8 @@ type Spec struct {
 	Proto      string `json:"proto,omitempty"`    // either "tcp" or "udp". in future "sctp" will be supported as well.
 	ParentIP   string `json:"parentIP,omitempty"` // IPv4 address. can be empty (0.0.0.0).
 	ParentPort int    `json:"parentPort,omitempty"`
+
+	ChildIP   string `json:"childIP,omitempty"`
 	ChildPort  int    `json:"childPort,omitempty"`
 }
 
@@ -44,6 +46,10 @@ type ParentDriver interface {
 	//
 	// ChildContext is optional.
 	RunParentDriver(initComplete chan struct{}, quit <-chan struct{}, cctx *ChildContext) error
+
+	// SetChildIP sets the IP to use for the connection inside the network namespace
+	// If not specified "127.0.0.1" is used.
+	SetChildIP(ip string) error
 }
 
 type ChildDriver interface {


### PR DESCRIPTION
allow users to override the IP to use for the connection inside the
network namespace.

It is useful e.g. with slirp4netns to override the IP to "10.0.2.100".

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>