### PR TITLE
port: add ChildIP

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.3 h1:twObb+9XcuH5B9V1TBCvvvZoO6iEdILi2a76PYn5rJI=
 github.com/google/uuid v1.1.3/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.4/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.5 h1:kxhtnfFVi+rYdOALN0B3k9UT86zVJKfBimRaciULW4I=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/pkg/port/builtin/child/child.go
+++ b/pkg/port/builtin/child/child.go
@@ -106,7 +106,21 @@ func (d *childDriver) handleConnectRequest(c *net.UnixConn, req *msg.Request) er
 		return errors.Errorf("unknown proto: %q", req.Proto)
 	}
 	var dialer net.Dialer
-	targetConn, err := dialer.Dial(req.Proto, fmt.Sprintf("127.0.0.1:%d", req.Port))
+	ip := req.IP
+	if ip == "" {
+		ip = "127.0.0.1"
+	} else {
+		p := net.ParseIP(ip)
+		if p == nil {
+			return errors.Errorf("invalid IP: %q", ip)
+		}
+		p = p.To4()
+		if p == nil {
+			return errors.Errorf("unsupported IP (v6?): %s", ip)
+		}
+		ip = p.String()
+	}
+	targetConn, err := dialer.Dial(req.Proto, fmt.Sprintf("%s:%d", ip, req.Port))
 	if err != nil {
 		return err
 	}

--- a/pkg/port/builtin/msg/msg.go
+++ b/pkg/port/builtin/msg/msg.go
@@ -20,6 +20,7 @@ const (
 type Request struct {
 	Type  string // "init" or "connect"
 	Proto string // "tcp" or "udp"
+	IP    string
 	Port  int
 }
 
@@ -53,6 +54,7 @@ func ConnectToChild(c *net.UnixConn, spec port.Spec) (int, error) {
 		Type:  RequestTypeConnect,
 		Proto: spec.Proto,
 		Port:  spec.ChildPort,
+		IP:    spec.ChildIP,
 	}
 	if _, err := msgutil.MarshalToWriter(c, &req); err != nil {
 		return 0, err

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -10,6 +10,7 @@ type Spec struct {
 	ParentIP   string `json:"parentIP,omitempty"` // IPv4 address. can be empty (0.0.0.0).
 	ParentPort int    `json:"parentPort,omitempty"`
 	ChildPort  int    `json:"childPort,omitempty"`
+	ChildIP    string `json:"childIP,omitempty"`  // IPv4 address. If not specified, "127.0.0.1" is used.
 }
 
 type Status struct {

--- a/pkg/port/slirp4netns/slirp4netns.go
+++ b/pkg/port/slirp4netns/slirp4netns.go
@@ -55,13 +55,27 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	if err != nil {
 		return nil, err
 	}
+	ip := spec.ChildIP
+	if ip == "" {
+		ip = d.childIP
+	} else {
+		p := net.ParseIP(ip)
+		if p == nil {
+			return nil, errors.Errorf("invalid IP: %q", ip)
+		}
+		p = p.To4()
+		if p == nil {
+			return nil, errors.Errorf("unsupported IP (v6?): %s", ip)
+		}
+		ip = p.String()
+	}
 	req := request{
 		Execute: "add_hostfwd",
 		Arguments: addHostFwdArguments{
 			Proto:     spec.Proto,
 			HostAddr:  spec.ParentIP,
 			HostPort:  spec.ParentPort,
-			GuestAddr: d.childIP,
+			GuestAddr: ip,
 			GuestPort: spec.ChildPort,
 		},
 	}


### PR DESCRIPTION
allow users to override the IP to use for the connection inside the
network namespace.

It is useful e.g. with slirp4netns to override the IP to "10.0.2.100".

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>