### PR TITLE
`rootlesskit --pidns`: disable reaper by default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/checkout@v2
     - name: "Build integration test image"
       run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration --target test-integration .
+    - name: "Integration test: exit-code"
+      run: docker run --rm --privileged rootlesskit:test-integration ./integration-exit-code.sh
     - name: "Integration test: propagation"
       run: docker run --rm --privileged rootlesskit:test-integration ./integration-propagation.sh
     - name: "Integration test: propagation (with `mount --make-rshared /`)"

--- a/hack/integration-exit-code.sh
+++ b/hack/integration-exit-code.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+source $(realpath $(dirname $0))/common.inc.sh
+
+function test_exit_code() {
+	args="$@"
+	set +e
+	for f in 0 42; do
+		$ROOTLESSKIT $args sh -exc "exit $f" >/dev/null 2>&1
+		code=$?
+		if [ $code = $f ]; then
+			INFO "exit $f works with \"$args\""
+		else
+			ERROR "exit $f does not work with \"$args\", got $code"
+			exit 1
+		fi
+	done
+}
+
+test_exit_code --pidns=false
+test_exit_code --pidns=true
+
+# FIXME(#129): test_exit_code --pidns=true --reaper=true

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -255,6 +255,8 @@ func Child(opt Opt) error {
 		return err
 	}
 	if opt.Reaper {
+		logrus.Warn("reaper is experimental")
+		logrus.Warn("reaper is known to have an issue about propagating process exit code (https://github.com/rootless-containers/rootlesskit/issues/129)")
 		if err := runAndReap(cmd); err != nil {
 			return errors.Wrapf(err, "command %v exited", opt.TargetCmd)
 		}


### PR DESCRIPTION
`rootlesskit --pidns` had been broken due to incomplete implementation of reaper (#129):
```
$ rootlesskit --pidns /bin/true
[rootlesskit:child ] error: command [/bin/true] exited: waitid: no child processes
[rootlesskit:parent] error: child exited: exit status 1
```

This commit disables reaper by default for `rootlesskit --pidns`.

The reaper can be still enabled by specifying `--reaper` flag.
