### PR TITLE
`rootlesskit --pidns`: fix propagating exit status

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/checkout@v2
     - name: "Build integration test image"
       run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration --target test-integration .
+    - name: "Integration test: exit-code"
+      run: docker run --rm --privileged rootlesskit:test-integration ./integration-exit-code.sh
     - name: "Integration test: propagation"
       run: docker run --rm --privileged rootlesskit:test-integration ./integration-propagation.sh
     - name: "Integration test: propagation (with `mount --make-rshared /`)"

--- a/hack/integration-exit-code.sh
+++ b/hack/integration-exit-code.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+source $(realpath $(dirname $0))/common.inc.sh
+
+function test_exit_code() {
+	args="$@"
+	INFO "Testig exit status for args=${args}"
+	set +e
+	for f in 0 42; do
+		$ROOTLESSKIT $args sh -exc "exit $f" >/dev/null 2>&1
+		code=$?
+		if [ $code != $f ]; then
+			ERROR "expected code $f, got $code"
+			exit 1
+		fi
+	done
+}
+
+test_exit_code --pidns=false
+test_exit_code --pidns=true --reaper=auto
+test_exit_code --pidns=true --reaper=true
+test_exit_code --pidns=true --reaper=false
+
+function test_signal() {
+	args="$@"
+	INFO "Testig signal for args=${args}"
+	set +e
+	tmp=$(mktemp -d)
+	$ROOTLESSKIT --state-dir=${tmp}/state $args sleep infinity >${tmp}/out 2>&1 &
+	pid=$!
+	sleep 1
+	kill -SIGUSR1 $(cat ${tmp}/state/child_pid)
+	wait $pid
+	code=$?
+	if [ $code != 255 ]; then
+		ERROR "expected code 255, got $code"
+		exit 1
+	fi
+	if ! grep -q "user defined signal 1" ${tmp}/out; then
+		ERROR "didn't get SIGUSR1?"
+		cat ${tmp}/out
+		exit 1
+	fi
+	rm -rf $tmp
+}
+
+test_signal --pidns=false
+test_signal --pidns=true --reaper=auto
+test_signal --pidns=true --reaper=true
+test_signal --pidns=true --reaper=false

--- a/pkg/common/exec.go
+++ b/pkg/common/exec.go
@@ -9,12 +9,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ErrorWithSys is implemented by *exec.ExitError and *child.reaperErr
+type ErrorWithSys interface {
+	error
+	Sys() interface{}
+}
+
 func GetExecExitStatus(err error) (int, bool) {
 	err = errors.Cause(err)
 	if err == nil {
 		return 0, false
 	}
-	exitErr, ok := err.(*exec.ExitError)
+	exitErr, ok := err.(ErrorWithSys)
 	if !ok {
 		return 0, false
 	}


### PR DESCRIPTION
`rootlesskit --pidns` had been broken due to incomplete implementation of reaper:
```
$ rootlesskit --pidns /bin/true
[rootlesskit:child ] error: command [/bin/true] exited: waitid: no child processes
[rootlesskit:parent] error: child exited: exit status 1
```

Fix #129