### PR TITLE
support cgroup2 evacuation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,10 @@ bin/rootlesskit-docker-proxy: $(GO_FILES)
 .PHONY: cross
 cross:
 	./hack/make-cross.sh
+
+BINDIR ?= /usr/local/bin
+.PHONY: install
+install:
+	install -D -m 755 $(CURDIR)/bin/rootlesskit $(DESTDIR)$(BINDIR)/rootlesskit
+	install -D -m 755 $(CURDIR)/bin/rootlessctl $(DESTDIR)$(BINDIR)/rootlessctl
+	install -D -m 755 $(CURDIR)/bin/rootlesskit-docker-proxy $(DESTDIR)$(BINDIR)/rootlesskit-docker-proxy

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ USAGE:
    rootlesskit [global options] [arguments...]
 
 VERSION:
-   0.11.0
+   0.13.0
 
 DESCRIPTION:
    RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
@@ -216,6 +216,8 @@ GLOBAL OPTIONS:
    --utsns                      create a UTS namespace (default: false)
    --ipcns                      create an IPC namespace (default: false)
    --propagation value          mount propagation [rprivate, rslave] (default: "rprivate")
+   --reaper value               enable process reaper. Requires --pidns. [auto,true,false] (default: "auto")
+   --evacuate-cgroup2 value     evacuate processes into the specified subgroup. Requires --pidns and --cgroupns
    --help, -h                   show help (default: false)
    --version, -v                print the version (default: false)
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The purpose of RootlessKit is to run [Docker and Kubernetes as an unprivileged u
 - [State directory](#state-directory)
 - [Environment variables](#environment-variables)
 - [PID Namespace](#pid-namespace)
+- [Cgroup Namespace](#cgroup-namespace)
+  - [Cgroup2 evacuation](#cgroup2-evacuation)
 - [Mount Propagation](#mount-propagation)
 - [Network Drivers](#network-drivers)
   - [`--net=host` (default)](#--nethost-default)
@@ -245,6 +247,18 @@ The RootlessKit child process becomes the init (PID=1).
 When RootlessKit terminates, all the processes in the namespace are killed with `SIGKILL`.
 
 See also [`pid_namespaces(7)`](http://man7.org/linux/man-pages/man7/pid_namespaces.7.html).
+
+## Cgroup Namespace
+When `--cgroupns` (since v0.10.0) is specified, RootlessKit executes the child process in a new cgroup namespace.
+
+### Cgroup2 evacuation
+Cgroup2 evacuation is supported since v0.13.0.
+
+e.g., `systemd-run -p Delegate=yes --user -t rootlesskit --cgroupns --pidns --evacuate-cgroup2=evac --net=slirp4netns bash`
+
+When the current process belongs to `/foo` group (visible under `/sys/fs/cgroup/foo`) and evacuation group name is like `bar`,
+- All processes in the `/foo` group are moved to `/foo/bar` group, by writing PIDs into `/sys/fs/cgroup/foo/bar/cgroup.procs`
+- As many controllers as possible are enabled for `/foo/*` groups, by writing `/sys/fs/cgroup/foo/cgroup.subtree_control`
 
 ## Mount Propagation
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -14,8 +13,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.1.5 h1:kxhtnfFVi+rYdOALN0B3k9UT86zVJKfBimRaciULW4I=
-github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
@@ -45,11 +43,9 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -74,7 +70,6 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/hack/integration-evacuate-cgroup2.sh
+++ b/hack/integration-evacuate-cgroup2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source $(realpath $(dirname $0))/common.inc.sh
+
+# Test requires systemd, so skipped on CI.
+# Should work on both unified mode and "hybrid" mode.
+
+# NOTE: extra sed is for eliminating tty escape sequence
+group="$(systemd-run --user -t -q -- $ROOTLESSKIT --cgroupns --pidns --evacuate-cgroup2=evac grep -oP '0::\K.*' /proc/self/cgroup | sed 's/[^[:print:]]//g')"
+if [ "$group" != "/evac" ]; then
+  ERROR "expected group \"/evac\", got \"${group}\"."
+  exit 1
+fi

--- a/pkg/parent/cgrouputil/cgrouputil.go
+++ b/pkg/parent/cgrouputil/cgrouputil.go
@@ -1,0 +1,114 @@
+package cgrouputil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/moby/sys/mountinfo"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// EvacuateCgroup2 evacuates cgroup2. Must be called in the parent PID namespace.
+//
+// When the current process belongs to "/foo" group (visible under "/sys/fs/cgroup/foo") and evac is like "bar",
+// - All processes in the "/foo" group are moved to "/foo/bar" group, by writing PIDs into "/sys/fs/cgroup/foo/bar/cgroup.procs"
+// - As many controllers as possible are enabled for "/foo/*" groups, by writing "/sys/fs/cgroup/foo/cgroup.subtree_control"
+//
+// Returns nil when cgroup2 is not enabled.
+// Ported from https://github.com/rootless-containers/usernetes/commit/46ad812db7489914897ff8b1774f2fab0efda62b
+func EvacuateCgroup2(evac string) error {
+	if evac == "" {
+		return errors.New("got empty evacuation group name")
+	}
+	if strings.Contains(evac, "/") {
+		return errors.Errorf("unexpected evacuation group name %q: must not contain \"/\"", evac)
+	}
+
+	mountpoint := findCgroup2Mountpoint()
+	if mountpoint == "" {
+		logrus.Warn("cgroup2 is not mounted. cgroup2 evacuation is discarded.")
+		return nil
+	}
+
+	oldGroup := getCgroup2(os.Getpid())
+	if mountpoint == "" {
+		logrus.Warn("process is not running with cgroup2. cgroup2 evacuation is discarded.")
+		return nil
+	}
+
+	newGroup := filepath.Join(oldGroup, evac)
+
+	oldPath := filepath.Join(mountpoint, oldGroup)
+	newPath := filepath.Join(mountpoint, newGroup)
+
+	if err := os.MkdirAll(newPath, 0755); err != nil {
+		return err
+	}
+
+	// evacuate existing procs from oldGroup to newGroup, so that we can enable all controllers including threaded ones
+	cgroupProcsBytes, err := ioutil.ReadFile(filepath.Join(oldPath, "cgroup.procs"))
+	if err != nil {
+		return err
+	}
+	for _, pidStr := range strings.Split(string(cgroupProcsBytes), "\n") {
+		if pidStr == "" || pidStr == "0" {
+			continue
+		}
+		if err := ioutil.WriteFile(filepath.Join(newPath, "cgroup.procs"), []byte(pidStr), 0644); err != nil {
+			logrus.WithError(err).Warnf("failed to move process %s to cgroup %q", pidStr, newGroup)
+		}
+	}
+
+	// enable controllers for all subgroups under the oldGroup
+	controllerBytes, err := ioutil.ReadFile(filepath.Join(oldPath, "cgroup.controllers"))
+	if err != nil {
+		return err
+	}
+	for _, controller := range strings.Fields(string(controllerBytes)) {
+		logrus.Debugf("enabling controller %q", controller)
+		if err := ioutil.WriteFile(filepath.Join(oldPath, "cgroup.subtree_control"), []byte("+"+controller), 0644); err != nil {
+			logrus.WithError(err).Warnf("failed to enable controller %q", controller)
+		}
+	}
+
+	return nil
+}
+
+func findCgroup2Mountpoint() string {
+	f := mountinfo.FSTypeFilter("cgroup2")
+	mounts, err := mountinfo.GetMounts(f)
+	if err != nil {
+		logrus.WithError(err).Warn("failed to find mountpoint for cgroup2")
+		return ""
+	}
+	if len(mounts) == 0 {
+		return ""
+	}
+	if len(mounts) != 1 {
+		logrus.Warnf("expected single mountpoint for cgroup2, got %d", len(mounts))
+	}
+	return mounts[0].Mountpoint
+}
+
+func getCgroup2(pid int) string {
+	p := fmt.Sprintf("/proc/%d/cgroup", pid)
+	b, err := ioutil.ReadFile(p)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to read %q", p)
+		return ""
+	}
+	return getCgroup2FromProcPidCgroup(b)
+}
+
+func getCgroup2FromProcPidCgroup(b []byte) string {
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(l, "0::") {
+			return strings.TrimPrefix(l, "0::")
+		}
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.13.0"
+const Version = "0.13.0+dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.12.0+dev"
+const Version = "0.13.0"


### PR DESCRIPTION
e.g. `systemd-run -p Delegate=yes --user -t rootlesskit --cgroupns --pidns --evacuate-cgroup2=evac --net=slirp4netns bash`

When the current process belongs to `/foo` group (visible under `/sys/fs/cgroup/foo`) and evac is like `bar`,
- All processes in the `/foo` group are moved to `/foo/bar` group, by writing PIDs into `/sys/fs/cgroup/foo/bar/cgroup.procs`
- As many controllers as possible are enabled for `/foo/*` groups, by writing `/sys/fs/cgroup/foo/cgroup.subtree_control`