### PR TITLE
Refactor ParsePortSpec to handle IPv6 addresses, and improve validation

### DIFF
--- a/pkg/port/builtin/parent/tcp/tcp.go
+++ b/pkg/port/builtin/parent/tcp/tcp.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/rootless-containers/rootlesskit/pkg/port"
@@ -12,7 +13,7 @@ import (
 )
 
 func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", spec.ParentIP, spec.ParentPort))
+	ln, err := net.Listen("tcp", net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
 		return err

--- a/pkg/port/builtin/parent/udp/udp.go
+++ b/pkg/port/builtin/parent/udp/udp.go
@@ -1,10 +1,10 @@
 package udp
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -14,7 +14,7 @@ import (
 )
 
 func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", spec.ParentIP, spec.ParentPort))
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
 	}

--- a/pkg/port/portutil/portutil.go
+++ b/pkg/port/portutil/portutil.go
@@ -128,6 +128,11 @@ func ValidatePortSpec(spec port.Spec, existingPorts map[int]*port.Status) error 
 			return errors.Errorf("invalid ParentIP: %q", spec.ParentIP)
 		}
 	}
+	if spec.ChildIP != "" {
+		if net.ParseIP(spec.ChildIP) == nil {
+			return errors.Errorf("invalid ChildIP: %q", spec.ChildIP)
+		}
+	}
 	if spec.ParentPort <= 0 || spec.ParentPort > 65535 {
 		return errors.Errorf("invalid ParentPort: %q", spec.ParentPort)
 	}

--- a/pkg/port/portutil/portutil.go
+++ b/pkg/port/portutil/portutil.go
@@ -4,63 +4,117 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"text/scanner"
 
 	"github.com/pkg/errors"
 
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 )
 
-// ParsePortSpec parses a Docker-like representation of PortSpec.
+// ParsePortSpec parses a Docker-like representation of PortSpec, but with
+// support for both "parent IP" and "child IP" (optional);
 // e.g. "127.0.0.1:8080:80/tcp", or "127.0.0.1:8080:10.0.2.100:80/tcp"
-func ParsePortSpec(s string) (*port.Spec, error) {
-	splitBySlash := strings.SplitN(s, "/", 2)
-	if len(splitBySlash) != 2 {
-		return nil, errors.Errorf("unexpected PortSpec string: %q", s)
-	}
-	proto := splitBySlash[1]
-	switch proto {
-	case "tcp", "udp", "sctp":
-	default:
-		return nil, errors.Errorf("unexpected Proto in PortSpec string: %q", s)
-	}
+//
+// Format is as follows:
+//
+//     <parent IP>:<parent port>[:<child IP>]:<child port>/<proto>
+//
+// Note that (child IP being optional) the format can either contain 5 or 4
+// components. When using IPv6 IP addresses, addresses must use square brackets
+// to prevent the colons being mistaken for delimiters. For example:
+//
+//     [::1]:8080:[::2]:80/udp
+func ParsePortSpec(portSpec string) (*port.Spec, error) {
+	const (
+		parentIP   = iota
+		parentPort = iota
+		childIP    = iota
+		childPort  = iota
+		proto      = iota
+	)
 
-	splitByColon := strings.SplitN(splitBySlash[0], ":", 4)
-	switch len(splitByColon) {
-	case 3, 4:
-	default:
-		return nil, errors.Errorf("unexpected PortSpec string: %q", s)
-	}
+	var (
+		s         scanner.Scanner
+		err       error
+		parts     = make([]string, 5)
+		index     = parentIP
+		delimiter = ':'
+	)
 
-	parentIP := splitByColon[0]
-	if net.IP(parentIP) == nil {
-		return nil, errors.Errorf("unexpected ParentIP in PortSpec string: %q", s)
-	}
+	// First get the "proto" and "parent-port" at the end. These parts are
+	// required, whereas "ParentIP" is optional. Removing them first makes
+	// it easier to parse the remaining parts, as otherwise the third part
+	// could be _either_ an IP-address _or_ a Port.
 
-	parentPort, err := strconv.Atoi(splitByColon[1])
+	// Get the proto
+	protoPos := strings.LastIndex(portSpec, "/")
+	if protoPos < 0 {
+		return nil, errors.Errorf("missing proto in PortSpec string: %q", portSpec)
+	}
+	parts[proto] = portSpec[protoPos+1:]
+	err = validateProto(parts[proto])
 	if err != nil {
-		return nil, errors.Wrapf(err, "unexpected ParentPort in PortSpec string: %q", s)
+		return nil, errors.Wrapf(err, "invalid PortSpec string: %q", portSpec)
 	}
 
-	var childIP string
-	if len(splitByColon) == 4 {
-		childIP = splitByColon[2]
-		if net.IP(childIP) == nil {
-			return nil, errors.Errorf("unexpected ChildIP in PortSpec string: %q", s)
+	// Get the parent port
+	portPos := strings.LastIndex(portSpec, ":")
+	if portPos < 0 {
+		return nil, errors.Errorf("unexpected PortSpec string: %q", portSpec)
+	}
+	parts[childPort] = portSpec[portPos+1 : protoPos]
+
+	// Scan the remainder "<IP-address>:<port>[:<IP-address>]"
+	s.Init(strings.NewReader(portSpec[:portPos]))
+
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		if index > childPort {
+			return nil, errors.Errorf("unexpected PortSpec string: %q", portSpec)
+		}
+
+		switch tok {
+		case '[':
+			// Start of IPv6 IP-address; value ends at closing bracket (])
+			delimiter = ']'
+			continue
+		case delimiter:
+			if delimiter == ']' {
+				// End of IPv6 IP-address
+				delimiter = ':'
+				// Skip the next token, which should be a colon delimiter (:)
+				tok = s.Scan()
+			}
+			index++
+			continue
+		default:
+			parts[index] += s.TokenText()
 		}
 	}
 
-	childPort, err := strconv.Atoi(splitByColon[len(splitByColon)-1])
-	if err != nil {
-		return nil, errors.Wrapf(err, "unexpected ChildPort in PortSpec string: %q", s)
+	if parts[parentIP] != "" && net.ParseIP(parts[parentIP]) == nil {
+		return nil, errors.Errorf("unexpected ParentIP in PortSpec string: %q", portSpec)
+	}
+	if parts[childIP] != "" && net.ParseIP(parts[childIP]) == nil {
+		return nil, errors.Errorf("unexpected ParentIP in PortSpec string: %q", portSpec)
 	}
 
-	return &port.Spec{
-		Proto:      proto,
-		ParentIP:   parentIP,
-		ParentPort: parentPort,
-		ChildIP:    childIP,
-		ChildPort:  childPort,
-	}, nil
+	ps := &port.Spec{
+		Proto:    parts[proto],
+		ParentIP: parts[parentIP],
+		ChildIP:  parts[childIP],
+	}
+
+	ps.ParentPort, err = strconv.Atoi(parts[parentPort])
+	if err != nil {
+		return nil, errors.Wrapf(err, "unexpected ChildPort in PortSpec string: %q", portSpec)
+	}
+
+	ps.ChildPort, err = strconv.Atoi(parts[childPort])
+	if err != nil {
+		return nil, errors.Wrapf(err, "unexpected ParentPort in PortSpec string: %q", portSpec)
+	}
+
+	return ps, nil
 }
 
 // ValidatePortSpec validates *port.Spec.
@@ -89,4 +143,13 @@ func ValidatePortSpec(spec port.Spec, existingPorts map[int]*port.Status) error 
 		}
 	}
 	return nil
+}
+
+func validateProto(proto string) error {
+	switch proto {
+	case "tcp", "udp", "sctp":
+		return nil
+	default:
+		return errors.Errorf("unknown proto: %q", proto)
+	}
 }

--- a/pkg/port/portutil/portutil.go
+++ b/pkg/port/portutil/portutil.go
@@ -120,8 +120,8 @@ func ParsePortSpec(portSpec string) (*port.Spec, error) {
 // ValidatePortSpec validates *port.Spec.
 // existingPorts can be optionally passed for detecting conflicts.
 func ValidatePortSpec(spec port.Spec, existingPorts map[int]*port.Status) error {
-	if spec.Proto != "tcp" && spec.Proto != "udp" {
-		return errors.Errorf("unknown proto: %q", spec.Proto)
+	if err := validateProto(spec.Proto); err != nil {
+		return err
 	}
 	if spec.ParentIP != "" {
 		if net.ParseIP(spec.ParentIP) == nil {

--- a/pkg/port/portutil/portutil_test.go
+++ b/pkg/port/portutil/portutil_test.go
@@ -45,21 +45,43 @@ func TestParsePortSpec(t *testing.T) {
 			s: "8080",
 			// future version may support short formats like this
 		},
+		{
+			s: "[::1]:8080:80/tcp",
+			expected: &port.Spec{
+				Proto:      "tcp",
+				ParentIP:   "::1",
+				ParentPort: 8080,
+				ChildPort:  80,
+			},
+		},
+		{
+			s: "[::1]:8080:[::2]:80/udp",
+			expected: &port.Spec{
+				Proto:      "udp",
+				ParentIP:   "::1",
+				ParentPort: 8080,
+				ChildIP:    "::2",
+				ChildPort:  80,
+			},
+		},
 	}
 	for _, tc := range testCases {
-		got, err := ParsePortSpec(tc.s)
-		if tc.expected == nil {
-			if err == nil {
-				t.Fatalf("error is expected for %q", tc.s)
+		tc := tc
+		t.Run(tc.s, func(t *testing.T) {
+			got, err := ParsePortSpec(tc.s)
+			if tc.expected == nil {
+				if err == nil {
+					t.Fatalf("error is expected for %q", tc.s)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("got error for %q: %v", tc.s, err)
+				}
+				if !reflect.DeepEqual(got, tc.expected) {
+					t.Fatalf("expected %+v, got %+v", tc.expected, got)
+				}
 			}
-		} else {
-			if err != nil {
-				t.Fatalf("got error for %q: %v", tc.s, err)
-			}
-			if !reflect.DeepEqual(got, tc.expected) {
-				t.Fatalf("expected %+v, got %+v", tc.expected, got)
-			}
-		}
+		})
 	}
 }
 

--- a/pkg/port/portutil/portutil_test.go
+++ b/pkg/port/portutil/portutil_test.go
@@ -133,6 +133,12 @@ func TestValidatePortSpec(t *testing.T) {
 
 	}
 
+	s := port.Spec{Proto: "tcp", ParentIP: "invalid", ParentPort: 80, ChildPort: 80}
+	assert.Error(t, ValidatePortSpec(s, existingPorts))
+
+	s = port.Spec{Proto: "tcp", ParentPort: 80, ChildIP: "invalid", ChildPort: 80}
+	assert.Error(t, ValidatePortSpec(s, existingPorts))
+
 	invalidPorts := []int{-200, 0, 1000000}
 	validPorts := []int{20, 500, 1337, 65000}
 
@@ -168,7 +174,7 @@ func TestValidatePortSpec(t *testing.T) {
 	// existing ports include tcp 10.10.10.10:8080, tcp *:80, no udp
 
 	// udp doesn't conflict with tcp
-	s := port.Spec{Proto: "udp", ParentPort: 80, ChildPort: 80}
+	s = port.Spec{Proto: "udp", ParentPort: 80, ChildPort: 80}
 	assert.NoError(t, ValidatePortSpec(s, existingPorts))
 
 	// same parent, same child, different IP has no conflict

--- a/pkg/port/portutil/portutil_test.go
+++ b/pkg/port/portutil/portutil_test.go
@@ -118,7 +118,7 @@ func TestValidatePortSpec(t *testing.T) {
 
 	// proto must be supplied and must equal "udp" or "tcp"
 	invalidProtos := []string{"", "NaN", "TCP"}
-	validProtos := []string{"udp", "tcp"}
+	validProtos := []string{"udp", "tcp", "sctp"}
 	for _, p := range invalidProtos {
 		s := spec
 		s.Proto = p


### PR DESCRIPTION
Refactor of portutil, related to https://github.com/moby/moby/pull/41908 and https://github.com/rootless-containers/rootlesskit/pull/207

### Refactor ParsePortSpec to handle IPv6 addresses

The PortSpec uses colons a delimiter between parts. If an IPv6 address is used, this leads to the colons in the IP-address to be handled as delimiter.

Commit 1d78bed8423d3377e04c4bdd1e1a045fb42e2942 (https://github.com/rootless-containers/rootlesskit/pull/207) also added support for "ChildIP" to the portspec format, which (adding to the above) made parsing the format even more ambiguous.

This patch rewrites ParsePortSpec to handle IPv6 addresses, but requires those addresses to be wrapped by square brackes.

### ValidatePortSpec: accept sctp as valid proto

There was an inconsistency between ParsePortSpec and ValidatePortSpec; ParsePortSpec accepted "sctp" as a valid proto, whereas ValidatePortSpec did not.

This patch re-uses the `validateProto()` function to validate.

### ValidatePortSpec: validate ChildIP (if set)

The function already validated ParentIP, but did not validate ChildIP; also added a minimal test

### Use net.JoinHostPort() to join IP-addresses with port

This makes sure the IPv6 addresses are wrapped with square brackets (e.g., `[::1]:8080`)
