### PR TITLE
CLI: improve `--help` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ allow
 ### Full CLI options
 
 ```console
+$ rootlesskit --help
 NAME:
    rootlesskit - Linux-native fakeroot using user namespaces
 
@@ -171,7 +172,7 @@ USAGE:
    rootlesskit [global options] [arguments...]
 
 VERSION:
-   0.13.0
+   0.13.2+dev
 
 DESCRIPTION:
    RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
@@ -193,33 +194,49 @@ DESCRIPTION:
    
    Note: RootlessKit requires /etc/subuid and /etc/subgid to be configured by the real root user.
 
-GLOBAL OPTIONS:
-   --debug                      debug mode (default: false)
-   --state-dir value            state directory
-   --net value                  network driver [host, slirp4netns, vpnkit, lxc-user-nic(experimental)] (default: "host")
-   --slirp4netns-binary value   path of slirp4netns binary for --net=slirp4netns (default: "slirp4netns")
-   --slirp4netns-sandbox value  enable slirp4netns sandbox (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
-   --slirp4netns-seccomp value  enable slirp4netns seccomp (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
-   --vpnkit-binary value        path of VPNKit binary for --net=vpnkit (default: "vpnkit")
-   --lxc-user-nic-binary value  path of lxc-user-nic binary for --net=lxc-user-nic (default: "/usr/lib/x86_64-linux-gnu/lxc/lxc-user-nic")
-   --lxc-user-nic-bridge value  lxc-user-nic bridge name (default: "lxcbr0")
-   --mtu value                  MTU for non-host network (default: 65520 for slirp4netns, 1500 for others) (default: 0)
-   --cidr value                 CIDR for slirp4netns network (default: 10.0.2.0/24)
-   --ifname value               Network interface name (default: tap0 for slirp4netns and vpnkit, eth0 for lxc-user-nic)
-   --disable-host-loopback      prohibit connecting to 127.0.0.1:* on the host namespace (default: false)
-   --copy-up value              mount a filesystem and copy-up the contents. e.g. "--copy-up=/etc" (typically required for non-host network)
-   --copy-up-mode value         copy-up mode [tmpfs+symlink] (default: "tmpfs+symlink")
-   --port-driver value          port driver for non-host network. [none, builtin, slirp4netns, socat(deprecated)] (default: "none")
-   --publish value, -p value    publish ports. e.g. "127.0.0.1:8080:80/tcp"
-   --pidns                      create a PID namespace (default: false)
-   --cgroupns                   create a cgroup namespace (default: false)
-   --utsns                      create a UTS namespace (default: false)
-   --ipcns                      create an IPC namespace (default: false)
-   --propagation value          mount propagation [rprivate, rslave] (default: "rprivate")
-   --reaper value               enable process reaper. Requires --pidns. [auto,true,false] (default: "auto")
-   --evacuate-cgroup2 value     evacuate processes into the specified subgroup. Requires --pidns and --cgroupns
-   --help, -h                   show help (default: false)
-   --version, -v                print the version (default: false)
+OPTIONS:
+  Debug:                         
+    --debug                      debug mode (default: false)
+                                 
+  Mount:                         
+    --copy-up value              mount a filesystem and copy-up the contents. e.g. "--copy-up=/etc" (typically required for non-host network)
+    --copy-up-mode value         copy-up mode [tmpfs+symlink] (default: "tmpfs+symlink")
+    --propagation value          mount propagation [rprivate, rslave] (default: "rprivate")
+                                 
+  Network:                       
+    --net value                  network driver [host, slirp4netns, vpnkit, lxc-user-nic(experimental)] (default: "host")
+    --mtu value                  MTU for non-host network (default: 65520 for slirp4netns, 1500 for others) (default: 0)
+    --cidr value                 CIDR for slirp4netns network (default: 10.0.2.0/24)
+    --ifname value               Network interface name (default: tap0 for slirp4netns and vpnkit, eth0 for lxc-user-nic)
+    --disable-host-loopback      prohibit connecting to 127.0.0.1:* on the host namespace (default: false)
+                                 
+  Network [lxc-user-nic]:        
+    --lxc-user-nic-binary value  path of lxc-user-nic binary for --net=lxc-user-nic (default: "/usr/lib/x86_64-linux-gnu/lxc/lxc-user-nic")
+    --lxc-user-nic-bridge value  lxc-user-nic bridge name (default: "lxcbr0")
+                                 
+  Network [slirp4netns]:         
+    --slirp4netns-binary value   path of slirp4netns binary for --net=slirp4netns (default: "slirp4netns")
+    --slirp4netns-sandbox value  enable slirp4netns sandbox (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
+    --slirp4netns-seccomp value  enable slirp4netns seccomp (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
+                                 
+  Network [vpnkit]:              
+    --vpnkit-binary value        path of VPNKit binary for --net=vpnkit (default: "vpnkit")
+                                 
+  Port:                          
+    --port-driver value          port driver for non-host network. [none, builtin, slirp4netns, socat(deprecated)] (default: "none")
+    --publish value, -p value    publish ports. e.g. "127.0.0.1:8080:80/tcp"
+                                 
+  Process:                       
+    --pidns                      create a PID namespace (default: false)
+    --cgroupns                   create a cgroup namespace (default: false)
+    --utsns                      create a UTS namespace (default: false)
+    --ipcns                      create an IPC namespace (default: false)
+    --reaper value               enable process reaper. Requires --pidns. [auto,true,false] (default: "auto")
+    --evacuate-cgroup2 value     evacuate processes into the specified subgroup. Requires --pidns and --cgroupns
+                                 
+  State:                         
+    --state-dir value            state directory
+                                 
 ```
 
 ## State directory

--- a/cmd/rootlesskit/category.go
+++ b/cmd/rootlesskit/category.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	CategoryDebug       = "Debug"
+	CategoryState       = "State"
+	CategoryNetwork     = "Network"
+	CategorySlirp4netns = "Network [slirp4netns]"
+	CategoryVPNKit      = "Network [vpnkit]"
+	CategoryLXCUserNic  = "Network [lxc-user-nic]"
+	CategoryPort        = "Port"
+	CategoryMount       = "Mount"
+	CategoryProcess     = "Process"
+)
+
+type CategorizedFlag interface {
+	cli.Flag
+	Category() string
+}
+
+func Categorize(f cli.Flag, category string) CategorizedFlag {
+	return &flag{
+		Flag:     f,
+		category: category,
+	}
+}
+
+type flag struct {
+	cli.Flag
+	category string
+}
+
+func (f *flag) Category() string {
+	return f.category
+}
+
+func formatFlags(flags []cli.Flag) string {
+	var res string
+	m := make(map[string][]cli.Flag)
+	for _, f := range flags {
+		cat := "(Uncategorized)"
+		if x, ok := f.(CategorizedFlag); ok {
+			if cat2 := x.Category(); cat2 != "" {
+				cat = cat2
+			}
+		}
+		if _, ok := m[cat]; !ok {
+			m[cat] = make([]cli.Flag, 0)
+		}
+		m[cat] = append(m[cat], f)
+	}
+
+	var catList []string
+	for c := range m {
+		catList = append(catList, c)
+	}
+	sort.Strings(catList)
+
+	for _, cat := range catList {
+		catFlags, ok := m[cat]
+		if !ok {
+			continue
+		}
+		res += fmt.Sprintf("  %s:\t\n", cat)
+		for _, f := range catFlags {
+			res += fmt.Sprintf("    %s\n", f.String())
+		}
+		res += "  \t\n"
+	}
+	return res
+}

--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -62,117 +62,131 @@ Examples:
 
 Note: RootlessKit requires /etc/subuid and /etc/subgid to be configured by the real root user.`
 	app.Flags = []cli.Flag{
-		&cli.BoolFlag{
+		Categorize(&cli.BoolFlag{
 			Name:        "debug",
 			Usage:       "debug mode",
 			Destination: &debug,
-		},
-		&cli.StringFlag{
+		}, CategoryDebug),
+		Categorize(&cli.StringFlag{
 			Name:  "state-dir",
 			Usage: "state directory",
-		},
-		&cli.StringFlag{
+		}, CategoryState),
+		Categorize(&cli.StringFlag{
 			Name:  "net",
 			Usage: "network driver [host, slirp4netns, vpnkit, lxc-user-nic(experimental)]",
 			Value: "host",
-		},
-		&cli.StringFlag{
+		}, CategoryNetwork),
+		Categorize(&cli.StringFlag{
 			Name:  "slirp4netns-binary",
 			Usage: "path of slirp4netns binary for --net=slirp4netns",
 			Value: "slirp4netns",
-		},
-		&cli.StringFlag{
+		}, CategorySlirp4netns),
+		Categorize(&cli.StringFlag{
 			Name:  "slirp4netns-sandbox",
 			Usage: "enable slirp4netns sandbox (experimental) [auto, true, false] (the default is planned to be \"auto\" in future)",
 			Value: "false",
-		},
-		&cli.StringFlag{
+		}, CategorySlirp4netns),
+		Categorize(&cli.StringFlag{
 			Name:  "slirp4netns-seccomp",
 			Usage: "enable slirp4netns seccomp (experimental) [auto, true, false] (the default is planned to be \"auto\" in future)",
 			Value: "false",
-		},
-		&cli.StringFlag{
+		}, CategorySlirp4netns),
+		Categorize(&cli.StringFlag{
 			Name:  "vpnkit-binary",
 			Usage: "path of VPNKit binary for --net=vpnkit",
 			Value: "vpnkit",
-		},
-		&cli.StringFlag{
+		}, CategoryVPNKit),
+		Categorize(&cli.StringFlag{
 			Name:  "lxc-user-nic-binary",
 			Usage: "path of lxc-user-nic binary for --net=lxc-user-nic",
 			Value: lxcUserNicBin(),
-		},
-		&cli.StringFlag{
+		}, CategoryLXCUserNic),
+		Categorize(&cli.StringFlag{
 			Name:  "lxc-user-nic-bridge",
 			Usage: "lxc-user-nic bridge name",
 			Value: "lxcbr0",
-		},
-		&cli.IntFlag{
+		}, CategoryLXCUserNic),
+		Categorize(&cli.IntFlag{
 			Name:  "mtu",
 			Usage: "MTU for non-host network (default: 65520 for slirp4netns, 1500 for others)",
 			Value: 0, // resolved into 65520 for slirp4netns, 1500 for others
-		},
-		&cli.StringFlag{
+		}, CategoryNetwork),
+		Categorize(&cli.StringFlag{
 			Name:  "cidr",
 			Usage: "CIDR for slirp4netns network (default: 10.0.2.0/24)",
-		},
-		&cli.StringFlag{
+		}, CategoryNetwork),
+		Categorize(&cli.StringFlag{
 			Name:  "ifname",
 			Usage: "Network interface name (default: tap0 for slirp4netns and vpnkit, eth0 for lxc-user-nic)",
-		},
-		&cli.BoolFlag{
+		}, CategoryNetwork),
+		Categorize(&cli.BoolFlag{
 			Name:  "disable-host-loopback",
 			Usage: "prohibit connecting to 127.0.0.1:* on the host namespace",
-		},
-		&cli.StringSliceFlag{
+		}, CategoryNetwork),
+		Categorize(&cli.StringSliceFlag{
 			Name:  "copy-up",
 			Usage: "mount a filesystem and copy-up the contents. e.g. \"--copy-up=/etc\" (typically required for non-host network)",
-		},
-		&cli.StringFlag{
+		}, CategoryMount),
+		Categorize(&cli.StringFlag{
 			Name:  "copy-up-mode",
 			Usage: "copy-up mode [tmpfs+symlink]",
 			Value: "tmpfs+symlink",
-		},
-		&cli.StringFlag{
+		}, CategoryMount),
+		Categorize(&cli.StringFlag{
 			Name:  "port-driver",
 			Usage: "port driver for non-host network. [none, builtin, slirp4netns, socat(deprecated)]",
 			Value: "none",
-		},
-		&cli.StringSliceFlag{
+		}, CategoryPort),
+		Categorize(&cli.StringSliceFlag{
 			Name:    "publish",
 			Aliases: []string{"p"},
 			Usage:   "publish ports. e.g. \"127.0.0.1:8080:80/tcp\"",
-		},
-		&cli.BoolFlag{
+		}, CategoryPort),
+		Categorize(&cli.BoolFlag{
 			Name:  "pidns",
 			Usage: "create a PID namespace",
-		},
-		&cli.BoolFlag{
+		}, CategoryProcess),
+		Categorize(&cli.BoolFlag{
 			Name:  "cgroupns",
 			Usage: "create a cgroup namespace",
-		},
-		&cli.BoolFlag{
+		}, CategoryProcess),
+		Categorize(&cli.BoolFlag{
 			Name:  "utsns",
 			Usage: "create a UTS namespace",
-		},
-		&cli.BoolFlag{
+		}, CategoryProcess),
+		Categorize(&cli.BoolFlag{
 			Name:  "ipcns",
 			Usage: "create an IPC namespace",
-		},
-		&cli.StringFlag{
+		}, CategoryProcess),
+		Categorize(&cli.StringFlag{
 			Name:  "propagation",
 			Usage: "mount propagation [rprivate, rslave]",
 			Value: "rprivate",
-		},
-		&cli.StringFlag{
+		}, CategoryMount),
+		Categorize(&cli.StringFlag{
 			Name:  "reaper",
 			Usage: "enable process reaper. Requires --pidns. [auto,true,false]",
 			Value: "auto",
-		},
-		&cli.StringFlag{
+		}, CategoryProcess),
+		Categorize(&cli.StringFlag{
 			Name:  "evacuate-cgroup2",
 			Usage: "evacuate processes into the specified subgroup. Requires --pidns and --cgroupns",
-		},
+		}, CategoryProcess),
 	}
+	app.CustomAppHelpTemplate = `NAME:
+   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description | nindent 3 | trim}}{{end}}
+
+OPTIONS:
+` + formatFlags(app.Flags)
 	app.Before = func(context *cli.Context) error {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)


### PR DESCRIPTION
```console
$ rootlesskit --help
NAME:
   rootlesskit - Linux-native fakeroot using user namespaces

USAGE:
   rootlesskit [global options] [arguments...]

VERSION:
   0.13.2+dev

DESCRIPTION:
   RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   
   Web site: https://github.com/rootless-containers/rootlesskit
   
   Examples:
     # spawn a shell with a new user namespace and a mount namespace
     rootlesskit bash
   
     # make /etc writable
     rootlesskit --copy-up=/etc bash
   
     # set mount propagation to rslave
     rootlesskit --propagation=rslave bash
   
     # create a network namespace with slirp4netns, and expose 80/tcp on the namespace as 8080/tcp on the host
     rootlesskit --copy-up=/etc --net=slirp4netns --disable-host-loopback --port-driver=builtin -p 127.0.0.1:8080:80/tcp bash
   
   Note: RootlessKit requires /etc/subuid and /etc/subgid to be configured by the real root user.

OPTIONS:
  Debug:                         
    --debug                      debug mode (default: false)
                                 
  Mount:                         
    --copy-up value              mount a filesystem and copy-up the contents. e.g. "--copy-up=/etc" (typically required for non-host network)
    --copy-up-mode value         copy-up mode [tmpfs+symlink] (default: "tmpfs+symlink")
    --propagation value          mount propagation [rprivate, rslave] (default: "rprivate")
                                 
  Network:                       
    --net value                  network driver [host, slirp4netns, vpnkit, lxc-user-nic(experimental)] (default: "host")
    --mtu value                  MTU for non-host network (default: 65520 for slirp4netns, 1500 for others) (default: 0)
    --cidr value                 CIDR for slirp4netns network (default: 10.0.2.0/24)
    --ifname value               Network interface name (default: tap0 for slirp4netns and vpnkit, eth0 for lxc-user-nic)
    --disable-host-loopback      prohibit connecting to 127.0.0.1:* on the host namespace (default: false)
                                 
  Network [lxc-user-nic]:        
    --lxc-user-nic-binary value  path of lxc-user-nic binary for --net=lxc-user-nic (default: "/usr/lib/x86_64-linux-gnu/lxc/lxc-user-nic")
    --lxc-user-nic-bridge value  lxc-user-nic bridge name (default: "lxcbr0")
                                 
  Network [slirp4netns]:         
    --slirp4netns-binary value   path of slirp4netns binary for --net=slirp4netns (default: "slirp4netns")
    --slirp4netns-sandbox value  enable slirp4netns sandbox (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
    --slirp4netns-seccomp value  enable slirp4netns seccomp (experimental) [auto, true, false] (the default is planned to be "auto" in future) (default: "false")
                                 
  Network [vpnkit]:              
    --vpnkit-binary value        path of VPNKit binary for --net=vpnkit (default: "vpnkit")
                                 
  Port:                          
    --port-driver value          port driver for non-host network. [none, builtin, slirp4netns, socat(deprecated)] (default: "none")
    --publish value, -p value    publish ports. e.g. "127.0.0.1:8080:80/tcp"
                                 
  Process:                       
    --pidns                      create a PID namespace (default: false)
    --cgroupns                   create a cgroup namespace (default: false)
    --utsns                      create a UTS namespace (default: false)
    --ipcns                      create an IPC namespace (default: false)
    --reaper value               enable process reaper. Requires --pidns. [auto,true,false] (default: "auto")
    --evacuate-cgroup2 value     evacuate processes into the specified subgroup. Requires --pidns and --cgroupns
                                 
  State:                         
    --state-dir value            state directory
                                 
```