### PR TITLE
Port API: support specifying IP version explicitly ("tcp4", "tcp6")

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,6 +27,9 @@ jobs:
       run: docker run --rm --privileged rootlesskit:test-integration sh -exc "sudo mount --make-rshared / && ./integration-propagation.sh"
     - name: "Integration test: restart"
       run: docker run --rm --privileged rootlesskit:test-integration ./integration-restart.sh
+    - name: "Integration test: port"
+      # NOTE: "--net=host" is a bad hack to enable IPv6
+      run: docker run --rm --net=host --privileged rootlesskit:test-integration ./integration-port.sh
 # ===== Benchmark: Network (MTU=1500) =====
     - name: "Benchmark: Network (MTU=1500, network driver=slirp4netns)"
       run: |

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ OPTIONS:
 The following files will be created in the state directory, which can be specified with `--state-dir`:
 * `lock`: lock file
 * `child_pid`: decimal PID text that can be used for `nsenter(1)`.
-* `api.sock`: REST API socket for `rootlessctl`. See [Port Drivers](./docs/port.md) section.
+* `api.sock`: REST API socket. See [`./docs/api.md`](./docs/api.md) and [`./docs/port.md`](./docs/port.md).
 
 If `--state-dir` is not specified, RootlessKit creates a temporary state directory on `/tmp` and removes it on exit.
 
@@ -248,3 +248,4 @@ Undocumented environment variables are subject to change.
 - [`./docs/port.md`](./docs/port.md): Port forwarding (`--port-driver`, `-p`, ...)
 - [`./docs/mount.md`](./docs/mount.md): Mount (`--propagation`, ...)
 - [`./docs/process.md`](./docs/process.md): Process (`--pidns`, `--reaper`, `--cgroupns`, `--evacuate-cgroup2`, ...)
+- [`./docs/api.md`](./docs/api.md): REST API

--- a/cmd/rootlessctl/info.go
+++ b/cmd/rootlessctl/info.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var infoCommand = cli.Command{
+	Name:      "info",
+	Usage:     "Show info",
+	ArgsUsage: "[flags]",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "Prints as JSON",
+		},
+	},
+	Action: infoAction,
+}
+
+func infoAction(clicontext *cli.Context) error {
+	w := clicontext.App.Writer
+	c, err := newClient(clicontext)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	info, err := c.Info(ctx)
+	if err != nil {
+		return err
+	}
+	if clicontext.Bool("json") {
+		m, err := json.MarshalIndent(info, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, string(m))
+		return nil
+	}
+	fmt.Fprintf(w, "- REST API version: %s\n", info.APIVersion)
+	fmt.Fprintf(w, "- Implementation version: %s\n", info.Version)
+	fmt.Fprintf(w, "- State Directory: %s\n", info.StateDir)
+	fmt.Fprintf(w, "- Child PID: %d\n", info.ChildPID)
+	if info.NetworkDriver != nil {
+		fmt.Fprintf(w, "- Network Driver: %s\n", info.NetworkDriver.Driver)
+		fmt.Fprintf(w, "  - DNS: %v\n", info.NetworkDriver.DNS)
+	}
+	if info.PortDriver != nil {
+		fmt.Fprintf(w, "- Port Driver: %s\n", info.PortDriver.Driver)
+		fmt.Fprintf(w, "  - Supported protocols: %v\n", info.PortDriver.Protos)
+	}
+	return nil
+}

--- a/cmd/rootlessctl/main.go
+++ b/cmd/rootlessctl/main.go
@@ -34,6 +34,7 @@ func main() {
 		&listPortsCommand,
 		&addPortsCommand,
 		&removePortsCommand,
+		&infoCommand,
 	}
 	app.Before = func(clicontext *cli.Context) error {
 		if debug {

--- a/cmd/rootlesskit-docker-proxy/main.go
+++ b/cmd/rootlesskit-docker-proxy/main.go
@@ -5,15 +5,18 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/rootless-containers/rootlesskit/pkg/api/client"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
+	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 )
@@ -35,6 +38,84 @@ func main() {
 	}
 }
 
+func isIPv6(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	return ip.To4() == nil
+}
+
+func getPortDriverProtos(c client.Client) (string, map[string]struct{}, error) {
+	info, err := c.Info(context.Background())
+	if err != nil {
+		return "", nil, errors.Wrap(err, "failed to call info API, probably RootlessKit binary is too old (needs to be v0.14.0 or later)")
+	}
+	if info.PortDriver == nil {
+		return "", nil, errors.New("no port driver is available")
+	}
+	m := make(map[string]struct{}, len(info.PortDriver.Protos))
+	for _, p := range info.PortDriver.Protos {
+		m[p] = struct{}{}
+	}
+	return info.PortDriver.Driver, m, nil
+}
+
+func callRootlessKitAPI(c client.Client,
+	hostIP string, hostPort int,
+	dockerProxyProto string) (func() error, error) {
+	// dockerProxyProto is like "tcp", but we need to convert it to "tcp4" or "tcp6" explicitly
+	// for libnetwork >= 20201216
+	//
+	// See https://github.com/moby/libnetwork/pull/2604/files#diff-8fa48beed55dd033bf8e4f8c40b31cf69d0b2cc5d4bb53cde8594670ea6c938aR20
+	// See also https://github.com/rootless-containers/rootlesskit/issues/231
+	apiProto := dockerProxyProto
+	if !strings.HasSuffix(apiProto, "4") && !strings.HasSuffix(apiProto, "6") {
+		if isIPv6(hostIP) {
+			apiProto += "6"
+		} else {
+			apiProto += "4"
+		}
+	}
+	portDriverName, apiProtos, err := getPortDriverProtos(c)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := apiProtos[apiProto]; !ok {
+		// This happens when apiProto="tcp6", portDriverName="slirp4netns",
+		// because "slirp4netns" port driver does not support listening on IPv6 yet.
+		//
+		// Note that "slirp4netns" port driver is not used by default,
+		// even when network driver is set to "slirp4netns".
+		//
+		// Most users are using "builtin" port driver and will not see this warning.
+		logrus.Warnf("protocol %q is not supported by the RootlessKit port driver %q, ignoring request for %q",
+			apiProto,
+			portDriverName,
+			net.JoinHostPort(hostIP, strconv.Itoa(hostPort)))
+		return nil, nil
+	}
+
+	pm := c.PortManager()
+	p := port.Spec{
+		Proto:      apiProto,
+		ParentIP:   hostIP,
+		ParentPort: hostPort,
+		ChildPort:  hostPort,
+	}
+	st, err := pm.AddPort(context.Background(), p)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while calling PortManager.AddPort()")
+	}
+	deferFunc := func() error {
+		if dErr := pm.RemovePort(context.Background(), st.ID); dErr != nil {
+			return errors.Wrap(err, "error while calling PortManager.RemovePort()")
+		}
+		return nil
+	}
+	return deferFunc, nil
+}
+
 func xmain(f *os.File) error {
 	containerIP := flag.String("container-ip", "", "container ip")
 	containerPort := flag.Int("container-port", -1, "container port")
@@ -52,23 +133,28 @@ func xmain(f *os.File) error {
 	if err != nil {
 		return errors.Wrap(err, "error while connecting to RootlessKit API socket")
 	}
-	pm := c.PortManager()
-	p := port.Spec{
-		Proto:      *proto,
-		ParentIP:   *hostIP,
-		ParentPort: *hostPort,
-		ChildPort:  *hostPort,
+
+	deferFunc, err := callRootlessKitAPI(c, *hostIP, *hostPort, *proto)
+	if deferFunc != nil {
+		defer func() {
+			if dErr := deferFunc(); dErr != nil {
+				logrus.Warn(dErr)
+			}
+		}()
 	}
-	st, err := pm.AddPort(context.Background(), p)
 	if err != nil {
-		return errors.Wrap(err, "error while calling PortManager.AddPort()")
+		return err
 	}
-	defer pm.RemovePort(context.Background(), st.ID)
+
+	realProxyHostIP := "127.0.0.1"
+	if isIPv6(*hostIP) {
+		realProxyHostIP = "::1"
+	}
 
 	cmd := exec.Command(realProxy,
 		"-container-ip", *containerIP,
 		"-container-port", strconv.Itoa(*containerPort),
-		"-host-ip", "127.0.0.1",
+		"-host-ip", realProxyHostIP,
 		"-host-port", strconv.Itoa(*hostPort),
 		"-proto", *proto)
 	cmd.Stdout = os.Stdout

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,62 @@
+# REST API
+
+RootlessKit listens REST API on `${ROOTLESSKIT_STATE_DIR}/api.sock`.
+
+```console
+(host)$ rootlesskit --net=slirp4netns --port-driver=builtin bash
+(rootlesskit)# curl -s --unix-socket "${ROOTLESSKIT_STATE_DIR}/api.sock" http://rootlesskit/v1/info | jq .
+{
+  "apiVersion": "1.1.0",
+  "version": "0.13.2+dev",
+  "stateDir": "/tmp/rootlesskit957151185",
+  "childPID": 157684,
+  "networkDriver": {
+    "driver": "slirp4netns",
+    "dns": [
+      "10.0.2.3"
+    ]
+  },
+  "portDriver": {
+    "driver": "builtin",
+    "protos": [
+      "tcp",
+      "udp"
+    ]
+  }
+}
+```
+
+## openapi.yaml
+
+See [`../pkg/api/openapi.yaml`](../pkg/api/openapi.yaml)
+
+## rootlessctl CLI
+
+`rootlessctl` is the CLI for the API.
+
+```console
+$ rootlessctl --help
+NAME:
+   rootlessctl - RootlessKit API client
+
+USAGE:
+   rootlessctl [global options] command [command options] [arguments...]
+
+VERSION:
+   0.13.2+dev
+
+COMMANDS:
+   list-ports    List ports
+   add-ports     Add ports
+   remove-ports  Remove ports
+   info          Show info
+   help, h       Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --debug         debug mode (default: false)
+   --socket value  Path to api.sock (under the "rootlesskit --state-dir" directory), defaults to $ROOTLESSKIT_STATE_DIR/api.sock
+   --help, -h      show help (default: false)
+   --version, -v   print the version (default: false)
+```
+
+e.g., `rootlessctl --socket /foo/bar/sock info --json`

--- a/docs/port.md
+++ b/docs/port.md
@@ -42,3 +42,17 @@ If you are using `builtin` driver, you can expose the privileged ports without c
 ```console
 $ sudo setcap cap_net_bind_service=ep $(pwd rootlesskit)
 ```
+
+### Note about IPv6
+
+Specifying `0.0.0.0:8080:80/tcp` may cause listening on IPv6 as well as on IPv4.
+Same applies to `[::]:8080:80/tcp`.
+
+This behavior may sound weird but corresponds to [Go's behavior](https://github.com/golang/go/commit/071908f3d809245eda42bf6eab071c323c67b7d2),
+so this is not a bug.
+
+To specify IPv4 explicitly, use `tcp4` instead of `tcp`, e.g., `0.0.0.0:8080:80/tcp4`.
+To specify IPv6 explicitly, use `tcp6`, e.g., `[::]:8080:80/tcp6`.
+
+The `tcp4` and `tcp6` forms were introduced in RootlessKit v0.14.0.
+The `tcp6` is currently supported only for `builtin` port driver.

--- a/hack/integration-port.sh
+++ b/hack/integration-port.sh
@@ -63,9 +63,21 @@ INFO "=== protocol \"tcp4\" is strictly v4-only ==="
 test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp4
 test_port builtin http://[::1]:8080 "should fail" -p 0.0.0.0:8080:80/tcp4
 
-INFO "=== protocol \"tcp6\" is strictly v4-only ==="
+INFO "=== protocol \"tcp6\" is strictly v6-only ==="
 test_port builtin http://127.0.0.1:8080 "should fail" -p [::]:8080:80/tcp6
 test_port builtin http://[::1]:8080 "should success" -p [::]:8080:80/tcp6
+
+INFO "=== v6-to-v6 ==="
+test_port builtin http://[::1]:8080 "should success" -p [::]:8080:[::1]:80/tcp6
+test_port builtin http://[::1]:8080 "should success" -p [::]:8080:[::1]:80/tcp
+
+INFO "=== v6-to-v4 ==="
+test_port builtin http://[::1]:8080 "should success" -p [::]:8080:[127.0.0.1]:80/tcp6
+test_port builtin http://[::1]:8080 "should success" -p [::]:8080:[127.0.0.1]:80/tcp
+
+INFO "=== v4-to-v6 ==="
+test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:[::1]:80/tcp4
+test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:[::1]:80/tcp
 
 INFO "=== \"tcp4\" and \"tcp6\" do not conflict ==="
 test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp4 -p [::]:8080:80/tcp6

--- a/hack/integration-port.sh
+++ b/hack/integration-port.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+source $(realpath $(dirname $0))/common.inc.sh
+
+# test_port PORT_DRIVER CURL_URL EXPECTATION [ROOTLESSKIT ARGS...]
+function test_port() {
+	args="$@"
+	port_driver="$1"
+	curl_url="$2"
+	expectation="$3"
+	shift
+	shift
+	shift
+	rootlesskit_args="$@"
+	INFO "Testing port_driver=\"${port_driver}\" curl_url=\"${curl_url}\" expectation=\"${expectation}\" rootlesskit_args=\"${rootlesskit_args}\""
+	tmp=$(mktemp -d)
+	state_dir=${tmp}/state
+	html_dir=${tmp}/html
+	mkdir -p ${html_dir}
+	echo "test_port ($args)" >${html_dir}/index.html
+	$ROOTLESSKIT \
+		--state-dir=${state_dir} \
+		--net=slirp4netns \
+		--disable-host-loopback \
+		--copy-up=/etc \
+		--port-driver=${port_driver} \
+		${rootlesskit_args} \
+		busybox httpd -f -v -p 80 -h ${html_dir} \
+		2>&1 &
+	pid=$!
+	sleep 1
+
+	set +e
+	curl -fsSL ${curl_url}
+	code=$?
+	set -e
+	if [ "${expectation}" = "should success" ]; then
+		if [ ${code} != 0 ]; then
+			ERROR "curl exited with ${code}"
+			exit ${code}
+		fi
+	elif [ "${expectation}" = "should fail" ]; then
+		if [ ${code} = 0 ]; then
+			ERROR "curl should not success"
+			exit 1
+		fi
+	else
+		ERROR "internal error"
+		exit 1
+	fi
+
+	INFO "Test pasing, stopping httpd (\"exit status 255\" is negligible here)"
+	kill -SIGTERM $(cat ${state_dir}/child_pid)
+	wait $pid >/dev/null 2>&1 || true
+	rm -rf $tmp
+}
+
+INFO "===== Port driver: builtin ====="
+INFO "=== protocol \"tcp\" listens on both v4 and v6 ==="
+test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp
+test_port builtin http://[::1]:8080 "should success" -p 0.0.0.0:8080:80/tcp
+
+INFO "=== protocol \"tcp4\" is strictly v4-only ==="
+test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp4
+test_port builtin http://[::1]:8080 "should fail" -p 0.0.0.0:8080:80/tcp4
+
+INFO "=== protocol \"tcp6\" is strictly v4-only ==="
+test_port builtin http://127.0.0.1:8080 "should fail" -p [::]:8080:80/tcp6
+test_port builtin http://[::1]:8080 "should success" -p [::]:8080:80/tcp6
+
+INFO "=== \"tcp4\" and \"tcp6\" do not conflict ==="
+test_port builtin http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp4 -p [::]:8080:80/tcp6
+
+INFO "===== Port driver: slirp4netns (IPv4 only)====="
+INFO "=== protocol \"tcp\" listens on v4 ==="
+test_port slirp4netns http://127.0.0.1:8080 "should success" -p 0.0.0.0:8080:80/tcp
+
+INFO "=== protocol \"tcp4\" is strictly v4-only ==="
+test_port slirp4netns http://[::1]:8080 "should fail" -p 0.0.0.0:8080:80/tcp4
+
+INFO "===== PASSING ====="

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,36 @@
 package api
 
+import "net"
+
+const (
+	// Version of the REST API, not implementation version.
+	// See openapi.yaml for the definition.
+	Version = "1.1.0"
+)
+
 // ErrorJSON is returned with "application/json" content type and non-2XX status code
 type ErrorJSON struct {
 	Message string `json:"message"`
+}
+
+// Info is the structure returned by `GET /info`
+type Info struct {
+	APIVersion    string             `json:"apiVersion"` // REST API version
+	Version       string             `json:"version"`    // Implementation version
+	StateDir      string             `json:"stateDir"`
+	ChildPID      int                `json:"childPID"`
+	NetworkDriver *NetworkDriverInfo `json:"networkDriver,omitempty"`
+	PortDriver    *PortDriverInfo    `json:"portDriver,omitempty"`
+}
+
+// NetworkDriverInfo in Info
+type NetworkDriverInfo struct {
+	Driver string   `json:"driver"`
+	DNS    []net.IP `json:"dns,omitempty"`
+}
+
+// PortDriverInfo in Info
+type PortDriverInfo struct {
+	Driver string   `json:"driver"`
+	Protos []string `json:"protos"`
 }

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -56,11 +56,17 @@ components:
   schemas:
     Proto:
       type: string
-      description: "protocol for listening"
+      description: "protocol for listening. Corresponds to Go's net.Listen. The strings with \"4\" and \"6\" suffixes were introduced in API 1.1.0."
       enum:
         - tcp
+        - tcp4
+        - tcp6
         - udp
+        - udp4
+        - udp6
         - sctp
+        - sctp4
+        - sctp6
     PortSpec:
       required:
         - proto

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -1,12 +1,22 @@
 # When you made a change to this YAML, please validate with https://editor.swagger.io
-openapi: 3.0.2
+openapi: 3.0.3
 info:
-  version: 1.0.1
+  version: 1.1.0
   title: RootlessKit API
 servers:
   - url: 'http://rootlesskit/v1'
     description: Local UNIX socket server. The host part of the URL is ignored.
 paths:
+# /info: API >= 1.1.0
+  /info:
+    get:
+      responses:
+        '200':
+          description: Info. Available since API 1.1.0.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
   /ports:
     get:
       responses:
@@ -44,16 +54,19 @@ paths:
           description: Null response
 components:
   schemas:
+    Proto:
+      type: string
+      description: "protocol for listening"
+      enum:
+        - tcp
+        - udp
+        - sctp
     PortSpec:
       required:
         - proto
       properties:
         proto:
-          type: string
-          enum:
-            - tcp
-            - udp
-            - sctp
+          $ref: '#/components/schemas/Proto'
         parentIP:
           type: string
         parentPort:
@@ -82,3 +95,61 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/PortStatus'
+# Info: API >= 1.1.0
+    Info:
+      required:
+        - apiVersion
+        - version
+        - stateDir
+        - childPID
+      properties:
+        apiVersion:
+          type: string
+          description: "API version, without \"v\" prefix"
+          example: "1.1.0"
+        version:
+          type: string
+          description: "Implementation version, without \"v\" prefix"
+          example: "0.42.0-beta.1+dev"
+        stateDir:
+          type: string
+          description: "state dir"
+          example: "/run/user/1000/rootlesskit"
+        childPID:
+          type: integer
+          description: "child PID"
+          example: 10042
+        networkDriver:
+          $ref: '#/components/schemas/NetworkDriverInfo'
+        portDriver:
+          $ref: '#/components/schemas/PortDriverInfo'
+    NetworkDriverInfo:
+      required:
+        - driver
+      properties:
+        driver:
+          type: string
+          description: "network driver. Empty when --net=host."
+          example: "slirp4netns"
+# TODO: return TAP info
+        dns:
+          type: array
+          description: "DNS addresses"
+          items:
+            type: string
+          example: ["10.0.2.3"]
+    PortDriverInfo:
+      required:
+        - driver
+        - supportedProtos
+      properties:
+        driver:
+          type: string
+          description: "port driver"
+          example: "builtin"
+        protos:
+          type: array
+          description: "The supported protocol strings for listening ports"
+          example: ["tcp","udp"]
+          items:
+            $ref: '#/components/schemas/Proto'

--- a/pkg/network/lxcusernic/lxcusernic.go
+++ b/pkg/network/lxcusernic/lxcusernic.go
@@ -1,6 +1,7 @@
 package lxcusernic
 
 import (
+	"context"
 	"net"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/common"
 	"github.com/rootless-containers/rootlesskit/pkg/network"
 )
@@ -46,6 +48,15 @@ type parentDriver struct {
 	mtu    int
 	bridge string
 	ifname string
+}
+
+const DriverName = "lxc-user-nic"
+
+func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error) {
+	return &api.NetworkDriverInfo{
+		Driver: DriverName,
+		// TODO: fill DNS
+	}, nil
 }
 
 func (d *parentDriver) MTU() int {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -1,11 +1,15 @@
 package network
 
 import (
+	"context"
+
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/common"
 )
 
 // ParentDriver is called from the parent namespace
 type ParentDriver interface {
+	Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 	// MTU returns MTU
 	MTU() int
 	// ConfigureNetwork sets up Slirp, updates msg, and returns destructor function.

--- a/pkg/parent/parent.go
+++ b/pkg/parent/parent.go
@@ -261,7 +261,12 @@ func Parent(opt Opt) error {
 	}
 	// listens the API
 	apiSockPath := filepath.Join(opt.StateDir, StateFileAPISock)
-	apiCloser, err := listenServeAPI(apiSockPath, &router.Backend{PortDriver: opt.PortDriver})
+	apiCloser, err := listenServeAPI(apiSockPath, &router.Backend{
+		StateDir:      opt.StateDir,
+		ChildPID:      cmd.Process.Pid,
+		NetworkDriver: opt.NetworkDriver,
+		PortDriver:    opt.PortDriver,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/port/builtin/msg/msg.go
+++ b/pkg/port/builtin/msg/msg.go
@@ -19,7 +19,7 @@ const (
 // Request and Response are encoded as JSON with uint32le length header.
 type Request struct {
 	Type  string // "init" or "connect"
-	Proto string // "tcp" or "udp"
+	Proto string // "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"
 	IP    string
 	Port  int
 }

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/msg"
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/opaque"
@@ -54,6 +55,14 @@ type driver struct {
 	ports              map[int]*port.Status
 	stoppers           map[int]func() error
 	nextID             int
+}
+
+func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
+	info := &api.PortDriverInfo{
+		Driver: "builtin",
+		Protos: []string{"tcp", "udp"},
+	}
+	return info, nil
 }
 
 func (d *driver) OpaqueForChild() map[string]string {

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -60,7 +60,7 @@ type driver struct {
 func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
 	info := &api.PortDriverInfo{
 		Driver: "builtin",
-		Protos: []string{"tcp", "udp"},
+		Protos: []string{"tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"},
 	}
 	return info, nil
 }
@@ -143,9 +143,9 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 		return nil // FIXME
 	}
 	switch spec.Proto {
-	case "tcp":
+	case "tcp", "tcp4", "tcp6":
 		err = tcp.Run(d.socketPath, spec, routineStopCh, d.logWriter)
-	case "udp":
+	case "udp", "udp4", "udp6":
 		err = udp.Run(d.socketPath, spec, routineStopCh, d.logWriter)
 	default:
 		// NOTREACHED

--- a/pkg/port/builtin/parent/tcp/tcp.go
+++ b/pkg/port/builtin/parent/tcp/tcp.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
-	ln, err := net.Listen("tcp", net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
+	ln, err := net.Listen(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
 		return err

--- a/pkg/port/builtin/parent/udp/udp.go
+++ b/pkg/port/builtin/parent/udp/udp.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
-	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
+	addr, err := net.ResolveUDPAddr(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
 	}
-	c, err := net.ListenUDP("udp", addr)
+	c, err := net.ListenUDP(spec.Proto, addr)
 	if err != nil {
 		return err
 	}

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -14,7 +14,7 @@ type Spec struct {
 	ParentIP   string `json:"parentIP,omitempty"` // IPv4 or IPv6 address. can be empty (0.0.0.0).
 	ParentPort int    `json:"parentPort,omitempty"`
 	ChildPort  int    `json:"childPort,omitempty"`
-	// ChildIP is an IPv4 address.
+	// ChildIP is an IPv4 or IPv6 address.
 	// Default values:
 	// - builtin     driver: 127.0.0.1
 	// - socat       driver: 127.0.0.1

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -8,8 +8,10 @@ import (
 )
 
 type Spec struct {
-	Proto      string `json:"proto,omitempty"`    // either "tcp" or "udp". in future "sctp" will be supported as well.
-	ParentIP   string `json:"parentIP,omitempty"` // IPv4 address. can be empty (0.0.0.0).
+	// Proto is one of ["tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"].
+	// "tcp" may cause listening on both IPv4 and IPv6. (Corresponds to Go's net.Listen .)
+	Proto      string `json:"proto,omitempty"`
+	ParentIP   string `json:"parentIP,omitempty"` // IPv4 or IPv6 address. can be empty (0.0.0.0).
 	ParentPort int    `json:"parentPort,omitempty"`
 	ChildPort  int    `json:"childPort,omitempty"`
 	// ChildIP is an IPv4 address.

--- a/pkg/port/port.go
+++ b/pkg/port/port.go
@@ -3,6 +3,8 @@ package port
 import (
 	"context"
 	"net"
+
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 )
 
 type Spec struct {
@@ -41,6 +43,7 @@ type ChildContext struct {
 // ParentDriver is a driver for the parent process.
 type ParentDriver interface {
 	Manager
+	Info(ctx context.Context) (*api.PortDriverInfo, error)
 	// OpaqueForChild typically consists of socket path
 	// for controlling child from parent
 	OpaqueForChild() map[string]string

--- a/pkg/port/portutil/portutil.go
+++ b/pkg/port/portutil/portutil.go
@@ -152,7 +152,10 @@ func ValidatePortSpec(spec port.Spec, existingPorts map[int]*port.Status) error 
 
 func validateProto(proto string) error {
 	switch proto {
-	case "tcp", "udp", "sctp":
+	case
+		"tcp", "tcp4", "tcp6",
+		"udp", "udp4", "udp6",
+		"sctp", "sctp4", "sctp6":
 		return nil
 	default:
 		return errors.Errorf("unknown proto: %q", proto)

--- a/pkg/port/portutil/portutil_test.go
+++ b/pkg/port/portutil/portutil_test.go
@@ -25,6 +25,15 @@ func TestParsePortSpec(t *testing.T) {
 			},
 		},
 		{
+			s: "127.0.0.1:8080:80/tcp4",
+			expected: &port.Spec{
+				Proto:      "tcp4",
+				ParentIP:   "127.0.0.1",
+				ParentPort: 8080,
+				ChildPort:  80,
+			},
+		},
+		{
 			s: "127.0.0.1:8080:10.0.2.100:80/tcp",
 			expected: &port.Spec{
 				Proto:      "tcp",

--- a/pkg/port/slirp4netns/slirp4netns.go
+++ b/pkg/port/slirp4netns/slirp4netns.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 	"github.com/rootless-containers/rootlesskit/pkg/port/portutil"
 )
@@ -32,6 +33,14 @@ type driver struct {
 	mu            sync.Mutex
 	childIP       string // can be empty
 	ports         map[int]*port.Status
+}
+
+func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
+	info := &api.PortDriverInfo{
+		Driver: "slirp4netns",
+		Protos: []string{"tcp", "udp"},
+	}
+	return info, nil
 }
 
 func (d *driver) OpaqueForChild() map[string]string {

--- a/pkg/port/socat/socat.go
+++ b/pkg/port/socat/socat.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/rootless-containers/rootlesskit/pkg/api"
 	"github.com/rootless-containers/rootlesskit/pkg/port"
 	"github.com/rootless-containers/rootlesskit/pkg/port/portutil"
 )
@@ -41,6 +42,14 @@ type driver struct {
 	ports     map[int]*port.Status
 	stoppers  map[int]func() error
 	nextID    int
+}
+
+func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
+	info := &api.PortDriverInfo{
+		Driver: "socat",
+		Protos: []string{"tcp", "udp"},
+	}
+	return info, nil
 }
 
 func (d *driver) OpaqueForChild() map[string]string {


### PR DESCRIPTION
# Commit 1: API: support `GET /info`
e.g.
```console
$ rootlessctl info -json
{
    "apiVersion": "1.1.0",
    "version": "0.13.2+dev",
    "stateDir": "/tmp/rootlesskit751356081",
    "childPID": 163654,
    "networkDriver": {
        "driver": "slirp4netns",
        "dns": [
            "10.0.2.3"
        ]
    },
    "portDriver": {
        "driver": "builtin",
        "protos": [
            "tcp",
            "udp"
        ]
    }
}
```

Inspecting `.portDriver.protos` is required for implementing https://github.com/rootless-containers/rootlesskit/issues/231#issuecomment-787714453

# Commit 2: Port API: support specifying IP version explicitly ("tcp4", "tcp6")
Fix #231

See `./docs.port.md`

```md
Specifying `0.0.0.0:8080:80/tcp` may cause listening on IPv6 as well as on IPv4.
Same applies to `[::]:8080:80/tcp`.

This behavior may sound weird but corresponds to [Go's behavior](https://github.com/golang/go/commit/071908f3d809245eda
42bf6eab071c323c67b7d2),
so this is not a bug.

To specify IPv4 explicitly, use `tcp4` instead of `tcp`, e.g., `0.0.0.0:8080:80/tcp4`.
To specify IPv6 explicitly, use `tcp6`, e.g., `[::]:8080:80/tcp6`.

The `tcp4` and `tcp6` forms were introduced in RootlessKit v0.14.0.
The `tcp6` is currently supported only for `builtin` port driver.
```

# Commit 3:  rootlesskit-docker-proxy: support libnetwork >= 20201216 convention

The `-proto` argument of `docker-proxy` is like "tcp", but we need to convert it to "tcp4" or "tcp6" explicitly when calling RootlessKit API, for libnetwork >= 20201216.

If the port driver does not support "tcp6" (especially when the port driver is slirp4netns), `rootlesskit-docker-proxy` skips exposing the port via RootlessKit API, without showing an error.

(We can't raise an error here, because `docker run -p 8080:80` always causes `rootlesskit-docker-proxy -host-ip ::` as well as `r-d-p -h-i 0.0.0.0`)

See https://github.com/moby/libnetwork/pull/2604/files#diff-8fa48beed55dd033bf8e4f8c40b31cf69d0b2cc5d4bb53cde8594670ea6c938aR20

See also https://github.com/rootless-containers/rootlesskit/issues/231

Using this version of `rootlesskit-docker-proxy` with libnetwork < 20201216 is also fine, because Rootless Docker had never officially supported IPv6.