### PR TITLE
allow vendoring with moby/sys/mountinfo@v0.1.3 as well as @v0.4.0

### DIFF
--- a/pkg/parent/cgrouputil/cgrouputil.go
+++ b/pkg/parent/cgrouputil/cgrouputil.go
@@ -79,7 +79,7 @@ func EvacuateCgroup2(evac string) error {
 }
 
 func findCgroup2Mountpoint() string {
-	f := mountinfo.FSTypeFilter("cgroup2")
+	f := mountinfoFSTypeFilter("cgroup2")
 	mounts, err := mountinfo.GetMounts(f)
 	if err != nil {
 		logrus.WithError(err).Warn("failed to find mountpoint for cgroup2")

--- a/pkg/parent/cgrouputil/moby_sys_mountinfo_tmphack.go
+++ b/pkg/parent/cgrouputil/moby_sys_mountinfo_tmphack.go
@@ -1,0 +1,44 @@
+package cgrouputil
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/moby/sys/mountinfo"
+)
+
+// mountinfoFSType returns m.Fstype on mountinfo v0.1.3,
+// returns m.FSType on mountinfo v0.4.0.
+func mountinfoFSType(m *mountinfo.Info) (string, bool) {
+	elem := reflect.ValueOf(m).Elem()
+	for i := 0; i < elem.NumField(); i++ {
+		typeField := elem.Type().Field(i)
+		name := typeField.Name
+		typ := typeField.Type.String()
+		if strings.ToLower(name) == "fstype" && typ == "string" {
+			value := elem.Field(i).String()
+			return value, true
+		}
+	}
+
+	return "", false
+}
+
+// mountinfoFSTypeFilter is reimplementation of mountinfo.FSTypeFilter.
+// Temporary solution for supporting both moby/sys/mountinfo@v0.1.3 and @v0.4.0 .
+// Will be removed after downstream projects stop using @v0.1.3 .
+func mountinfoFSTypeFilter(fstype ...string) mountinfo.FilterFunc {
+	return func(m *mountinfo.Info) (bool, bool) {
+		mFSType, ok := mountinfoFSType(m)
+		if !ok {
+			panic(fmt.Errorf("failed to get Fstype (FSType) of %+v", m))
+		}
+		for _, t := range fstype {
+			if mFSType == t {
+				return false, false // don't skeep, keep going
+			}
+		}
+		return true, false // skip, keep going
+	}
+}


### PR DESCRIPTION
Downstream projects (especially k3s) still depends on moby/sys/mountinfo@v0.1.3, which is incompatible with mountinfo@v0.4.0. ("Fstype" vs "FSType") https://github.com/moby/sys/commit/ad7461a5435ef0a9d6b8b89de26ec8c2da5f94a5

This commit adds `relect` hack to support vendoring with the both versions
