### PR TITLE
new experimental flag: --ipv6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,8 @@ jobs:
     - name: "Integration test: port"
       # NOTE: "--net=host" is a bad hack to enable IPv6
       run: docker run --rm --net=host --privileged rootlesskit:test-integration ./integration-port.sh
+    - name: "Integration test: IPv6 routing"
+      run: docker run  --rm --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 rootlesskit:test-integration ./integration-ipv6.sh
 # ===== Benchmark: Network (MTU=1500) =====
     - name: "Benchmark: Network (MTU=1500, network driver=slirp4netns)"
       run: |

--- a/docs/network.md
+++ b/docs/network.md
@@ -42,6 +42,7 @@ Pros:
 * Possible to perform network-namespaced operations, e.g. creating iptables rules, running `tcpdump`
 * Supports ICMP Echo (`ping`) when `/proc/sys/net/ipv4/ping_group_range` is configured
 * Supports hardening using mount namespace and seccomp (`--slirp4netns-sandbox=auto`, `--slirp4netns-seccomp=auto`, since RootlessKit v0.7.0, slirp4netns v0.4.0)
+* Supports IPv6 routing (`--ipv6`)
 
 Cons:
 * Extra performance overhead (but still faster than `--net=vpnkit`)
@@ -118,6 +119,7 @@ Pros:
 Cons:
 * Extra performance overhead
 * Supports only TCP and UDP packets. No support for ICMP Echo (`ping`) unlike `--net=slirp4netns`, even if `/proc/sys/net/ipv4/ping_group_range` is configured.
+* No support for IPv6.
 
 To use `--net=vpnkit`, you need to install VPNkit.
 
@@ -148,6 +150,7 @@ Pros:
 Cons:
 * Less secure
 * Needs `/etc/lxc/lxc-usernet` configuration
+* No support for IPv6.
 
 To use `lxc-user-nic`, you need to install `liblxc-common` package:
 ```console
@@ -168,3 +171,8 @@ If you start and stop RootlessKit too frequently, you might use up all available
 You might need to reset `/var/lib/misc/dnsmasq.lxcbr0.leases` and restart the `lxc-net` service.
 
 Currently, the MAC address is always set to a random address.
+
+## IPv6
+
+The `--ipv6` flag (since v0.14.0, EXPERIMENTAL) enables IPv6 routing for slirp4netns network driver.
+This flag is unrelated to port forwarding.

--- a/hack/integration-ipv6.sh
+++ b/hack/integration-ipv6.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source $(realpath $(dirname $0))/common.inc.sh
+set -x
+
+parent_ipv6="fdaa:aaaa:aaaa::1"
+parent_dummy="dummy42"
+
+sudo ip link add ${parent_dummy} type dummy
+sudo ip link set dev ${parent_dummy} up
+sudo ip addr add "${parent_ipv6}/64" dev ${parent_dummy}
+
+tmp=$(mktemp -d)
+echo "hello ipv6" >${tmp}/index.html
+
+busybox httpd -f -p "[${parent_ipv6}]:8080" -h "${tmp}" &
+pid=$!
+
+$ROOTLESSKIT \
+	--net=slirp4netns \
+	--ipv6 \
+	sh -euc "sleep 3; exec curl -fsSL http://[${parent_ipv6}]:8080"
+
+kill -9 $pid || true
+sudo ip link del ${parent_dummy}
+rm -rf ${tmp}


### PR DESCRIPTION
Enables IPv6 routing (`slirp4netns --enable-ipv6`).
Unrelated to port driver.
