### PR TITLE
rootlesskit-docker-proxy: fix support for slirp4netns port driver

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,16 +94,25 @@ jobs:
       uses: actions/checkout@v2
     - name: "Build integration test image"
       run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration-docker --target test-integration-docker .
+    - name: "Create a custom name to avoid IP confusion"
+      run: docker network create custom
     - name: "Docker Integration test: net=slirp4netns, port-driver=builtin"
       run: |
-        docker run -d --name test --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin rootlesskit:test-integration-docker
+        docker run -d --name test --network custom --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin rootlesskit:test-integration-docker
+        sleep 2
+        docker exec test docker info
+        docker exec test ./integration-docker.sh
+        docker rm -f test
+    - name: "Docker Integration test: net=slirp4netns, port-driver=slirp4netns"
+      run: |
+        docker run -d --name test --network custom --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=slirp4netns rootlesskit:test-integration-docker
         sleep 2
         docker exec test docker info
         docker exec test ./integration-docker.sh
         docker rm -f test
     - name: "Docker Integration test: net=vpnkit, port-driver=builtin"
       run: |
-        docker run -d --name test --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=vpnkit      -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin rootlesskit:test-integration-docker
+        docker run -d --name test --network custom --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=vpnkit      -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin rootlesskit:test-integration-docker
         sleep 2
         docker exec test docker info
         docker exec test ./integration-docker.sh

--- a/cmd/rootlessctl/info.go
+++ b/cmd/rootlessctl/info.go
@@ -47,6 +47,9 @@ func infoAction(clicontext *cli.Context) error {
 	if info.NetworkDriver != nil {
 		fmt.Fprintf(w, "- Network Driver: %s\n", info.NetworkDriver.Driver)
 		fmt.Fprintf(w, "  - DNS: %v\n", info.NetworkDriver.DNS)
+		if info.NetworkDriver.ChildIP != nil {
+			fmt.Fprintf(w, "  - IP: %v\n", info.NetworkDriver.ChildIP)
+		}
 	}
 	if info.PortDriver != nil {
 		fmt.Fprintf(w, "- Port Driver: %s\n", info.PortDriver.Driver)

--- a/cmd/rootlessctl/port.go
+++ b/cmd/rootlessctl/port.go
@@ -52,12 +52,12 @@ func listPortsAction(clicontext *cli.Context) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
-	if _, err := fmt.Fprintln(w, "ID\tPROTO\tPARENTIP\tPARENTPORT\tCHILDPORT\t"); err != nil {
+	if _, err := fmt.Fprintln(w, "ID\tPROTO\tPARENTIP\tPARENTPORT\tCHILDIP\tCHILDPORT\t"); err != nil {
 		return err
 	}
 	for _, p := range portStatuses {
-		if _, err := fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\t\n",
-			p.ID, p.Spec.Proto, p.Spec.ParentIP, p.Spec.ParentPort, p.Spec.ChildPort); err != nil {
+		if _, err := fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\t%d\t\n",
+			p.ID, p.Spec.Proto, p.Spec.ParentIP, p.Spec.ParentPort, p.Spec.ChildIP, p.Spec.ChildPort); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,7 +5,7 @@ import "net"
 const (
 	// Version of the REST API, not implementation version.
 	// See openapi.yaml for the definition.
-	Version = "1.1.0"
+	Version = "1.1.1"
 )
 
 // ErrorJSON is returned with "application/json" content type and non-2XX status code
@@ -25,12 +25,15 @@ type Info struct {
 
 // NetworkDriverInfo in Info
 type NetworkDriverInfo struct {
-	Driver string   `json:"driver"`
-	DNS    []net.IP `json:"dns,omitempty"`
+	Driver         string   `json:"driver"`
+	DNS            []net.IP `json:"dns,omitempty"`
+	ChildIP        net.IP   `json:"childIP,omitempty"`        // since API v1.1.1 (RootlessKit v0.14.1)
+	DynamicChildIP bool     `json:"dynamicChildIP,omitempty"` // since API v1.1.1
 }
 
 // PortDriverInfo in Info
 type PortDriverInfo struct {
-	Driver string   `json:"driver"`
-	Protos []string `json:"protos"`
+	Driver                  string   `json:"driver"`
+	Protos                  []string `json:"protos"`
+	DisallowLoopbackChildIP bool     `json:"disallowLoopbackChildIP,omitempty"` // since API v1.1.1
 }

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -1,7 +1,7 @@
 # When you made a change to this YAML, please validate with https://editor.swagger.io
 openapi: 3.0.3
 info:
-  version: 1.1.0
+  version: 1.1.1
   title: RootlessKit API
 servers:
   - url: 'http://rootlesskit/v1'
@@ -144,6 +144,13 @@ components:
           items:
             type: string
           example: ["10.0.2.3"]
+        childIP:
+          type: string
+          description: "Child IP (v4)"
+          example: "10.0.2.100"
+        dynamicChildIP:
+          type: boolean
+          description: "Child IP may change"
     PortDriverInfo:
       required:
         - driver
@@ -159,3 +166,6 @@ components:
           example: ["tcp","udp"]
           items:
             $ref: '#/components/schemas/Proto'
+        disallowLoopbackChildIP:
+          type: boolean
+          description: "If this field is set to true, loopback IP such as 127.0.0.1 cannot be specified as a child IP"

--- a/pkg/network/lxcusernic/lxcusernic.go
+++ b/pkg/network/lxcusernic/lxcusernic.go
@@ -56,6 +56,8 @@ func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 	return &api.NetworkDriverInfo{
 		Driver: DriverName,
 		// TODO: fill DNS
+		// TODO: fill IP
+		DynamicChildIP: true,
 	}, nil
 }
 

--- a/pkg/network/slirp4netns/slirp4netns.go
+++ b/pkg/network/slirp4netns/slirp4netns.go
@@ -257,8 +257,10 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir string) (*common.
 	d.infoMu.Lock()
 	d.info = func() *api.NetworkDriverInfo {
 		return &api.NetworkDriverInfo{
-			Driver: DriverName,
-			DNS:    []net.IP{net.ParseIP(netmsg.DNS)},
+			Driver:    DriverName,
+			DNS:       []net.IP{net.ParseIP(netmsg.DNS)},
+			ChildIP:        net.ParseIP(netmsg.IP),
+			DynamicChildIP: false,
 		}
 	}
 	d.infoMu.Unlock()

--- a/pkg/network/vpnkit/vpnkit.go
+++ b/pkg/network/vpnkit/vpnkit.go
@@ -134,8 +134,10 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir string) (*common.
 	d.infoMu.Lock()
 	d.info = func() *api.NetworkDriverInfo {
 		return &api.NetworkDriverInfo{
-			Driver: DriverName,
-			DNS:    []net.IP{net.ParseIP(netmsg.DNS)},
+			Driver:    DriverName,
+			DNS:       []net.IP{net.ParseIP(netmsg.DNS)},
+			ChildIP:        net.ParseIP(netmsg.IP),
+			DynamicChildIP: false,
 		}
 	}
 	d.infoMu.Unlock()

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -59,8 +59,9 @@ type driver struct {
 
 func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
 	info := &api.PortDriverInfo{
-		Driver: "builtin",
-		Protos: []string{"tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"},
+		Driver:                  "builtin",
+		Protos:                  []string{"tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"},
+		DisallowLoopbackChildIP: false,
 	}
 	return info, nil
 }

--- a/pkg/port/slirp4netns/slirp4netns.go
+++ b/pkg/port/slirp4netns/slirp4netns.go
@@ -40,7 +40,8 @@ func (d *driver) Info(ctx context.Context) (*api.PortDriverInfo, error) {
 	info := &api.PortDriverInfo{
 		Driver: "slirp4netns",
 		// No IPv6 support yet
-		Protos: []string{"tcp", "tcp4", "udp", "udp4"},
+		Protos:                  []string{"tcp", "tcp4", "udp", "udp4"},
+		DisallowLoopbackChildIP: true,
 	}
 	return info, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.14.0+dev"
+const Version = "0.14.1"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.14.1"
+const Version = "0.14.1+dev"


### PR DESCRIPTION
Fix rootless-containers/slirp4netns#261