### PR TITLE
CI: test Go 1.13 compatibility

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,8 @@ jobs:
     - name: "Check out"
       uses: actions/checkout@v2
     - name: "Build integration test image"
-      run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration-docker --target test-integration-docker .
+      # Docker builds RootlessKit with Go 1.13, so we use Go 1.13 as well here.
+      run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration-docker --target test-integration-docker --build-arg GO_VERSION=1.13 .
     - name: "Create a custom network to avoid IP confusion"
       run: docker network create custom
     - name: "Docker Integration test: net=slirp4netns, port-driver=builtin"


### PR DESCRIPTION
Docker builds RootlessKit with Go 1.13, so we should use Go 1.13 as well
for Docker integration tests.

