### PR TITLE
port/builtin: RemovePort() block until conn is closed

### DIFF
--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -140,8 +141,13 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	}
 	routineStopCh := make(chan struct{})
 	routineStop := func() error {
-		close(routineStopCh)
-		return nil // FIXME
+		routineStopCh <- struct{}{}
+		select {
+		case <-routineStopCh:
+		case <-time.After(5 * time.Second):
+			return errors.New("stop timeout after 5 seconds")
+		}
+		return nil
 	}
 	switch spec.Proto {
 	case "tcp", "tcp4", "tcp6":

--- a/pkg/port/builtin/parent/tcp/tcp.go
+++ b/pkg/port/builtin/parent/tcp/tcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/msg"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
 	ln, err := net.Listen(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
@@ -31,7 +31,10 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 		}
 	}()
 	go func() {
-		defer ln.Close()
+		defer func() {
+			ln.Close()
+			close(stopCh)
+		}()
 		for {
 			select {
 			case c, ok := <-newConns:

--- a/pkg/port/builtin/parent/udp/udp.go
+++ b/pkg/port/builtin/parent/udp/udp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udpproxy"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
 	addr, err := net.ResolveUDPAddr(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
@@ -51,6 +51,7 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 			case <-stopCh:
 				// udpp.Close closes ln as well
 				udpp.Close()
+				close(stopCh)
 				return
 			}
 		}


### PR DESCRIPTION
RemovePort() should block until the connection is closed. This allows
the caller to safely use AddPort() afterwards.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>