### PR TITLE
port/builtin: RemovePort() block until conn is closed, take 2 + Release v0.14.4

### DIFF
--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -41,7 +42,7 @@ func NewDriver(logWriter io.Writer, stateDir string) (port.ParentDriver, error) 
 		socketPath:         socketPath,
 		childReadyPipePath: childReadyPipePath,
 		ports:              make(map[int]*port.Status, 0),
-		stoppers:           make(map[int]func() error, 0),
+		stoppers:           make(map[int]func(context.Context) error, 0),
 		nextID:             1,
 	}
 	return &d, nil
@@ -53,7 +54,7 @@ type driver struct {
 	childReadyPipePath string
 	mu                 sync.Mutex
 	ports              map[int]*port.Status
-	stoppers           map[int]func() error
+	stoppers           map[int]func(context.Context) error
 	nextID             int
 }
 
@@ -138,16 +139,27 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	if err != nil {
 		return nil, err
 	}
+	// NOTE: routineStopCh is close-only channel. Do not send any data.
+	// See commit 4803f18fae1e39d200d98f09e445a97ccd6f5526 `Revert "port/builtin: RemovePort() block until conn is closed"`
 	routineStopCh := make(chan struct{})
-	routineStop := func() error {
+	routineStoppedCh := make(chan error)
+	routineStop := func(ctx context.Context) error {
 		close(routineStopCh)
-		return nil // FIXME
+		select {
+		case stoppedResult, stoppedResultOk := <-routineStoppedCh:
+			if stoppedResultOk {
+				return stoppedResult
+			}
+			return errors.New("routineStoppedCh was closed without sending data?")
+		case <-ctx.Done():
+			return errors.Wrap(err, "timed out while waiting for routineStoppedCh after closing routineStopCh")
+		}
 	}
 	switch spec.Proto {
 	case "tcp", "tcp4", "tcp6":
-		err = tcp.Run(d.socketPath, spec, routineStopCh, d.logWriter)
+		err = tcp.Run(d.socketPath, spec, routineStopCh, routineStoppedCh, d.logWriter)
 	case "udp", "udp4", "udp6":
-		err = udp.Run(d.socketPath, spec, routineStopCh, d.logWriter)
+		err = udp.Run(d.socketPath, spec, routineStopCh, routineStoppedCh, d.logWriter)
 	default:
 		// NOTREACHED
 		return nil, errors.New("spec was not validated?")
@@ -188,7 +200,12 @@ func (d *driver) RemovePort(ctx context.Context, id int) error {
 	if !ok {
 		return errors.Errorf("unknown id: %d", id)
 	}
-	err := stop()
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+	err := stop(ctx)
 	delete(d.stoppers, id)
 	delete(d.ports, id)
 	return err

--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -141,13 +140,8 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	}
 	routineStopCh := make(chan struct{})
 	routineStop := func() error {
-		routineStopCh <- struct{}{}
-		select {
-		case <-routineStopCh:
-		case <-time.After(5 * time.Second):
-			return errors.New("stop timeout after 5 seconds")
-		}
-		return nil
+		close(routineStopCh)
+		return nil // FIXME
 	}
 	switch spec.Proto {
 	case "tcp", "tcp4", "tcp6":

--- a/pkg/port/builtin/parent/tcp/tcp.go
+++ b/pkg/port/builtin/parent/tcp/tcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/msg"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, stoppedCh chan error, logWriter io.Writer) error {
 	ln, err := net.Listen(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
@@ -31,7 +31,10 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 		}
 	}()
 	go func() {
-		defer ln.Close()
+		defer func() {
+			stoppedCh <- ln.Close()
+			close(stoppedCh)
+		}()
 		for {
 			select {
 			case c, ok := <-newConns:

--- a/pkg/port/builtin/parent/tcp/tcp.go
+++ b/pkg/port/builtin/parent/tcp/tcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/msg"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
 	ln, err := net.Listen(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
@@ -31,10 +31,7 @@ func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.W
 		}
 	}()
 	go func() {
-		defer func() {
-			ln.Close()
-			close(stopCh)
-		}()
+		defer ln.Close()
 		for {
 			select {
 			case c, ok := <-newConns:

--- a/pkg/port/builtin/parent/udp/udp.go
+++ b/pkg/port/builtin/parent/udp/udp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udpproxy"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, stoppedCh chan error, logWriter io.Writer) error {
 	addr, err := net.ResolveUDPAddr(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
@@ -51,6 +51,8 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 			case <-stopCh:
 				// udpp.Close closes ln as well
 				udpp.Close()
+				stoppedCh <- nil
+				close(stoppedCh)
 				return
 			}
 		}

--- a/pkg/port/builtin/parent/udp/udp.go
+++ b/pkg/port/builtin/parent/udp/udp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udpproxy"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
 	addr, err := net.ResolveUDPAddr(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
@@ -51,7 +51,6 @@ func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.W
 			case <-stopCh:
 				// udpp.Close closes ln as well
 				udpp.Close()
-				close(stopCh)
 				return
 			}
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.14.4"
+const Version = "0.14.4+dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.14.3+dev"
+const Version = "0.14.4"


### PR DESCRIPTION
Revert #262 (https://github.com/rootless-containers/rootlesskit/pull/262/files#r682338302) and add an alternative.
