### PR TITLE
Update go.mod to have go1.17 as the minmium version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,8 +93,7 @@ jobs:
     - name: "Check out"
       uses: actions/checkout@v3
     - name: "Build integration test image"
-      # Docker 20.10.x builds RootlessKit with Go 1.16 (as of Docker 20.10.14), so we use Go 1.16 as well here.
-      run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration-docker --target test-integration-docker --build-arg GO_VERSION=1.16 .
+      run: DOCKER_BUILDKIT=1 docker build -t rootlesskit:test-integration-docker --target test-integration-docker --build-arg GO_VERSION=1.17 .
     - name: "Create a custom network to avoid IP confusion"
       run: docker network create custom
     - name: "Docker Integration test: net=slirp4netns, port-driver=builtin"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rootless-containers/rootlesskit
 
-go 1.16
+go 1.17
 
 require (
 	github.com/gofrs/flock v0.8.1
@@ -14,4 +14,14 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.4.0
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
* The Dockerfile already builds for go1.17. Therefore updating the go.mod to go1.17.
* Update README instructions to use go install instead of go get as go get won't add executable binaries in the future.

