### PR TITLE
new network driver: `pasta` (with port driver `implicit`)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,6 +62,14 @@ jobs:
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-net.sh vpnkit 1500 --detach-netns
+    - name: "Benchmark: Network (MTU=1500, network driver=pasta)"
+      run: |
+          docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
+          rootlesskit:test-integration ./benchmark-iperf3-net.sh pasta 1500
+    - name: "Benchmark: Network (MTU=1500, network driver=pasta) with detach-netns"
+      run: |
+          docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
+          rootlesskit:test-integration ./benchmark-iperf3-net.sh pasta 1500 --detach-netns
     - name: "Benchmark: Network (MTU=1500, network driver=lxc-user-nic)"
       run: |
           docker run --rm --privileged \
@@ -79,6 +87,10 @@ jobs:
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-net.sh slirp4netns 65520 --slirp4netns-sandbox=auto --slirp4netns-seccomp=auto
+    - name: "Benchmark: Network (MTU=65520, network driver=pasta)"
+      run: |
+          docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
+          rootlesskit:test-integration ./benchmark-iperf3-net.sh pasta 65520
     - name: "Benchmark: Network (MTU=65520, network driver=lxc-user-nic)"
       run: |
           docker run --rm --privileged \
@@ -88,22 +100,30 @@ jobs:
           docker run --rm --privileged \
           rootlesskit:test-integration ./benchmark-iperf3-net.sh rootful_veth 65520
 # ===== Benchmark: TCP Ports =====
-    - name: "Benchmark: TCP Ports (port driver=slirp4netns)"
+    - name: "Benchmark: TCP Ports (network driver=slirp4netns, port driver=slirp4netns)"
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-port.sh slirp4netns
-    - name: "Benchmark: TCP Ports (port driver=slirp4netns) with detach-netns"
+    - name: "Benchmark: TCP Ports (network driver=slirp4netns, port driver=slirp4netns) with detach-netns"
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-port.sh slirp4netns --detach-netns
-    - name: "Benchmark: TCP Ports (port driver=builtin)"
+    - name: "Benchmark: TCP Ports (network driver=slirp4netns, port driver=builtin)"
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-port.sh builtin
-    - name: "Benchmark: TCP Ports (port driver=builtin) with detach-netns"
+    - name: "Benchmark: TCP Ports (network driver=slirp4netns, port driver=builtin) with detach-netns"
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-port.sh builtin --detach-netns
+    - name: "Benchmark: TCP Ports (network driver=pasta, port driver=implicit)"
+      run: |
+          docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
+          rootlesskit:test-integration ./benchmark-iperf3-port.sh implicit --net=pasta
+    - name: "Benchmark: TCP Ports (network driver=pasta, port driver=implicit) with detach-netns"
+      run: |
+          docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
+          rootlesskit:test-integration ./benchmark-iperf3-port.sh implicit --net=pasta --detach-netns
 # ===== Benchmark: UDP Ports =====
     - name: "Benchmark: UDP Ports (port driver=slirp4netns)"
       run: |
@@ -121,6 +141,7 @@ jobs:
       run: |
           docker run --rm --security-opt seccomp=unconfined --security-opt apparmor=unconfined --device /dev/net/tun \
           rootlesskit:test-integration ./benchmark-iperf3-port-udp.sh builtin --detach-netns
+# pasta+builtin does not work with UDP yet
   test-integration-docker:
     name: "Integration test (Docker)"
     runs-on: ubuntu-latest
@@ -148,6 +169,13 @@ jobs:
     - name: "Docker Integration test: net=vpnkit, port-driver=builtin"
       run: |
         docker run -d --name test --network custom --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=vpnkit      -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=builtin rootlesskit:test-integration-docker
+        sleep 2
+        docker exec test docker info
+        docker exec test ./integration-docker.sh
+        docker rm -f test
+    - name: "Docker Integration test: net=pasta, port-driver=implicit"
+      run: |
+        docker run -d --name test --network custom --privileged -e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=pasta       -e DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=implicit rootlesskit:test-integration-docker
         sleep 2
         docker exec test docker info
         docker exec test ./integration-docker.sh

--- a/cmd/rootlesskit-docker-proxy/main.go
+++ b/cmd/rootlesskit-docker-proxy/main.go
@@ -152,6 +152,15 @@ func xmain(f *os.File) error {
 		return fmt.Errorf("failed to call info API, probably RootlessKit binary is too old (needs to be v0.14.0 or later): %w", err)
 	}
 
+	// info.PortDriver is currently nil for "none" and "implicit", but this may change in future
+	if info.PortDriver == nil || info.PortDriver.Driver == "none" || info.PortDriver.Driver == "implicit" {
+		realProxyExe, err := exec.LookPath(realProxy)
+		if err != nil {
+			return err
+		}
+		return syscall.Exec(realProxyExe, append([]string{realProxy}, os.Args[1:]...), os.Environ())
+	}
+
 	// use loopback IP as the child IP, when port-driver="builtin"
 	childIP := "127.0.0.1"
 	if isIPv6(*hostIP) {

--- a/cmd/rootlesskit/category.go
+++ b/cmd/rootlesskit/category.go
@@ -10,6 +10,7 @@ import (
 const (
 	CategoryState       = "State"
 	CategoryNetwork     = "Network"
+	CategoryPasta       = "Network [pasta]"
 	CategorySlirp4netns = "Network [slirp4netns]"
 	CategoryVPNKit      = "Network [vpnkit]"
 	CategoryLXCUserNic  = "Network [lxc-user-nic]"

--- a/docs/network.md
+++ b/docs/network.md
@@ -3,6 +3,7 @@
 RootlessKit provides several drivers for providing network connectivity:
 
 * `--net=host`: use host network namespace (default)
+* `--net=pasta`: use [pasta](https://passt.top/passt/) (experimental)
 * `--net=slirp4netns`: use [slirp4netns](https://github.com/rootless-containers/slirp4netns) (recommended)
 * `--net=vpnkit`: use [VPNKit](https://github.com/moby/vpnkit)
 * `--net=lxc-user-nic`: use `lxc-user-nic` (experimental)
@@ -137,6 +138,29 @@ The network is configured as follows by default:
 
 As in `--net=slirp4netns`, specifying `--copy-up=/etc` and `--disable-host-loopback` is highly recommended.
 If `--disable-host-loopback` is not specified, ports listening on 127.0.0.1 in the host are accessible as 192.168.65.2 in the RootlessKit's network namespace.
+
+### `--net=pasta` (experimental)
+
+`--net=pasta` (since RootlessKit v2.0, EXPERIMENTAL) uses [pasta (passt)](https://passt.top/passt/).
+`--net=pasta` is expected to be used in conjunction with `--port-driver=implicit`.
+
+> **Note**
+> `--net=pasta` needs [pasta (passt)](https://passt.top/passt/) `2023_06_25.32660ce` or later.
+>
+> Depending on the version of pasta and the host operating system,
+> running `sudo apparmor_parser -R /etc/apparmor.d/usr.bin.passt` might be needed too.
+
+Pros:
+* Possible to perform network-namespaced operations, e.g. creating iptables rules, running `tcpdump`
+* Supports ICMP Echo (`ping`) when `/proc/sys/net/ipv4/ping_group_range` is configured
+* TCP port forwarding (`--port-driver=implicit`) is very fast
+* TCP port forwarding (`--port-driver=implicit`) can retain source IP addresses
+
+Cons:
+* UDP port forwarding is not supported yet
+
+The network configuration for pasta is similar to slirp4netns.
+As in `--net=slirp4netns`, specifying `--copy-up=/etc` and `--disable-host-loopback` is highly recommended.
 
 ### `--net=lxc-user-nic` (experimental)
 

--- a/docs/port.md
+++ b/docs/port.md
@@ -12,7 +12,11 @@ The default value is `none` (do not expose ports).
 
 ([Benchmark: iperf3 from the parent to the child (Mar 8, 2020)](https://github.com/rootless-containers/rootlesskit/runs/492498728))
 
-The `builtin` driver is fastest, but be aware that the source IP is not propagated and always set to 127.0.0.1.
+The `builtin` driver is fast, but be aware that the source IP is not propagated and always set to 127.0.0.1.
+
+For [`pasta`](./network.md) networks, the `implicit` port driver is the best choice.
+
+* To be documented: [`bypass4netns`](https://github.com/rootless-containers/bypass4netns) for native performance.
 
 ### Exposing ports
 For example, to expose 80 in the child as 8080 in the parent:

--- a/hack/benchmark-iperf3-net.sh
+++ b/hack/benchmark-iperf3-net.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 source $(realpath $(dirname $0))/common.inc.sh
+function benchmark::iperf3::pasta() {
+	INFO "[benchmark:iperf3] slirp4netns ($@)"
+	statedir=$(mktemp -d)
+	if echo "$@" | grep -q -- --detach-netns; then
+		IPERF3C="nsenter -n${statedir}/netns $IPERF3C"
+	fi
+	set -x
+	$ROOTLESSKIT --state-dir=$statedir --net=slirp4netns $@ -- $IPERF3C 10.0.2.2
+	set +x
+}
+
 function benchmark::iperf3::slirp4netns() {
 	INFO "[benchmark:iperf3] slirp4netns ($@)"
 	statedir=$(mktemp -d)

--- a/hack/benchmark-iperf3-port-udp.sh
+++ b/hack/benchmark-iperf3-port-udp.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
+# TODO: merge this script into benchmark-iperf3-port.sh
 source $(realpath $(dirname $0))/common.inc.sh
 function benchmark::iperf3::port::udp() {
 	statedir=$(mktemp -d)
 	INFO "[benchmark:iperf3::port::udp] $@"
+	portdriver="$1"
+	shift
+	flags="$@"
 	IPERF3="iperf3"
 	if echo "$@" | grep -q -- --detach-netns; then
 		IPERF3="nsenter -n${statedir}/netns $IPERF3"
 	fi
-	$ROOTLESSKIT --state-dir=$statedir $@ $IPERF3 -s >/dev/null &
+	$ROOTLESSKIT $flags --port-driver=$portdriver --state-dir=$statedir $IPERF3 -s >/dev/null &
 	rkpid=$!
 	# wait for socket to be available
 	sleep 3
 	rootlessctl="rootlessctl --socket=$statedir/api.sock"
-	portids=$($rootlessctl add-ports 127.0.0.1:5201:5201/tcp 127.0.0.1:5201:5201/udp)
-	$rootlessctl list-ports
+	if [ $portdriver != "implicit" ]; then
+		portids=$($rootlessctl add-ports 127.0.0.1:5201:5201/tcp 127.0.0.1:5201:5201/udp)
+		$rootlessctl list-ports
+	fi
 	sleep 3
 	$IPERF3C 127.0.0.1 -u -b 100G
-	$rootlessctl remove-ports $portids
+	if [ $portdriver != "implicit" ]; then
+		$rootlessctl remove-ports $portids
+	fi
 	kill $rkpid
 }
 
@@ -24,8 +32,13 @@ if [ $# -lt 1 ]; then
 	ERROR "Usage: $0 PORTDRIVER [FLAGS...]"
 	exit 1
 fi
-port=$1
+portdriver=$1
 shift 1
 flags=$@
+if ! echo $flags | grep -q -- "--net"; then
+	flags="$flags --net=slirp4netns"
+fi
+flags="$flags --mtu=65520"
 
-benchmark::iperf3::port::udp --net=slirp4netns --mtu=65520 --port-driver=${port} $flags
+set -x
+benchmark::iperf3::port::udp ${portdriver} $flags

--- a/hack/benchmark-iperf3-port.sh
+++ b/hack/benchmark-iperf3-port.sh
@@ -3,19 +3,26 @@ source $(realpath $(dirname $0))/common.inc.sh
 function benchmark::iperf3::port() {
 	statedir=$(mktemp -d)
 	INFO "[benchmark:iperf3::port] $@"
+	portdriver="$1"
+	shift
+	flags="$@"
 	IPERF3="iperf3"
 	if echo "$@" | grep -q -- --detach-netns; then
 		IPERF3="nsenter -n${statedir}/netns $IPERF3"
 	fi
-	$ROOTLESSKIT --state-dir=$statedir $@ $IPERF3 -s >/dev/null &
+	$ROOTLESSKIT $flags --port-driver=$portdriver --state-dir=$statedir $IPERF3 -s >/dev/null &
 	rkpid=$!
 	# wait for socket to be available
 	sleep 3
 	rootlessctl="rootlessctl --socket=$statedir/api.sock"
-	portid=$($rootlessctl add-ports 127.0.0.1:5201:5201/tcp)
-	$rootlessctl list-ports
+	if [ $portdriver != "implicit" ]; then
+		portid=$($rootlessctl add-ports 127.0.0.1:5201:5201/tcp)
+		$rootlessctl list-ports
+	fi
 	$IPERF3C 127.0.0.1
-	$rootlessctl remove-ports $portid
+	if [ $portdriver != "implicit" ]; then
+		$rootlessctl remove-ports $portid
+	fi
 	kill $rkpid
 }
 
@@ -23,8 +30,14 @@ if [ $# -lt 1 ]; then
 	ERROR "Usage: $0 PORTDRIVER [FLAGS...]"
 	exit 1
 fi
-port=$1
+portdriver=$1
 shift 1
 flags=$@
 
-benchmark::iperf3::port --net=slirp4netns --mtu=65520 --port-driver=${port} $flags
+if ! echo $flags | grep -q -- "--net"; then
+	flags="$flags --net=slirp4netns"
+fi
+flags="$flags --mtu=65520"
+
+set -x
+benchmark::iperf3::port ${portdriver} $flags

--- a/hack/integration-docker.sh
+++ b/hack/integration-docker.sh
@@ -20,10 +20,14 @@ $CURL "http://127.0.0.1:8080"
 $CURL "http://${nonloopback}:8080" && ( ERROR "should fail"; exit 1 )
 docker rm -f nginx
 
-docker run -d --name=nginx -p "${nonloopback}:8080:80" nginx:alpine
-sleep 2
-$CURL "http://127.0.0.1:8080" && ( ERROR "should fail"; exit 1 )
-$CURL "http://${nonloopback}:8080"
-docker rm -f nginx
+# port driver "implicit" does not support binding on a non-loopback address:
+# "Error starting userland proxy: listen tcp4 172.18.0.2:8080: bind: cannot assign requested address."
+if [ "$DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER" != "implicit" ]; then
+	docker run -d --name=nginx -p "${nonloopback}:8080:80" nginx:alpine
+	sleep 2
+	$CURL "http://127.0.0.1:8080" && ( ERROR "should fail"; exit 1 )
+	$CURL "http://${nonloopback}:8080"
+	docker rm -f nginx
+fi
 
 INFO "===== PASSING ====="

--- a/pkg/network/pasta/pasta.go
+++ b/pkg/network/pasta/pasta.go
@@ -1,0 +1,197 @@
+package pasta
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strconv"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/rootless-containers/rootlesskit/pkg/api"
+	"github.com/rootless-containers/rootlesskit/pkg/common"
+	"github.com/rootless-containers/rootlesskit/pkg/messages"
+	"github.com/rootless-containers/rootlesskit/pkg/network"
+	"github.com/rootless-containers/rootlesskit/pkg/network/iputils"
+	"github.com/rootless-containers/rootlesskit/pkg/network/parentutils"
+)
+
+// NewParentDriver instantiates new parent driver.
+func NewParentDriver(logWriter io.Writer, binary string, mtu int, ipnet *net.IPNet, ifname string,
+	disableHostLoopback, enableIPv6, implicitPortForwarding bool) (network.ParentDriver, error) {
+	if binary == "" {
+		return nil, errors.New("got empty slirp4netns binary")
+	}
+	if mtu < 0 {
+		return nil, errors.New("got negative mtu")
+	}
+	if mtu == 0 {
+		mtu = 65520
+	}
+
+	if ipnet == nil {
+		var err error
+		_, ipnet, err = net.ParseCIDR("10.0.2.0/24")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if ifname == "" {
+		ifname = "tap0"
+	}
+
+	return &parentDriver{
+		logWriter:              logWriter,
+		binary:                 binary,
+		mtu:                    mtu,
+		ipnet:                  ipnet,
+		disableHostLoopback:    disableHostLoopback,
+		enableIPv6:             enableIPv6,
+		ifname:                 ifname,
+		implicitPortForwarding: implicitPortForwarding,
+	}, nil
+}
+
+type parentDriver struct {
+	logWriter              io.Writer
+	binary                 string
+	mtu                    int
+	ipnet                  *net.IPNet
+	disableHostLoopback    bool
+	enableIPv6             bool
+	ifname                 string
+	infoMu                 sync.RWMutex
+	implicitPortForwarding bool
+	info                   func() *api.NetworkDriverInfo
+}
+
+const DriverName = "pasta"
+
+func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error) {
+	d.infoMu.RLock()
+	infoFn := d.info
+	d.infoMu.RUnlock()
+	if infoFn == nil {
+		return &api.NetworkDriverInfo{
+			Driver: DriverName,
+		}, nil
+	}
+
+	return infoFn(), nil
+}
+
+func (d *parentDriver) MTU() int {
+	return d.mtu
+}
+
+func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPath string) (*messages.ParentInitNetworkDriverCompleted, func() error, error) {
+	tap := d.ifname
+	var cleanups []func() error
+	if err := parentutils.PrepareTap(childPID, detachedNetNSPath, tap); err != nil {
+		return nil, common.Seq(cleanups), fmt.Errorf("setting up tap %s: %w", tap, err)
+	}
+
+	address, err := iputils.AddIPInt(d.ipnet.IP, 100)
+	if err != nil {
+		return nil, common.Seq(cleanups), err
+	}
+	netmask, _ := d.ipnet.Mask.Size()
+	gateway, err := iputils.AddIPInt(d.ipnet.IP, 2)
+	if err != nil {
+		return nil, common.Seq(cleanups), err
+	}
+	dns, err := iputils.AddIPInt(d.ipnet.IP, 3)
+	if err != nil {
+		return nil, common.Seq(cleanups), err
+	}
+
+	opts := []string{
+		"--foreground",
+		"--stderr",
+		"--ns-ifname=" + d.ifname,
+		"--mtu=" + strconv.Itoa(d.mtu),
+		"--no-dhcp",
+		"--no-ra",
+		"--address=" + address.String(),
+		"--netmask=" + strconv.Itoa(netmask),
+		"--gateway=" + gateway.String(),
+		"--dns-forward=" + dns.String(),
+	}
+	if d.disableHostLoopback {
+		opts = append(opts, "--no-map-gw")
+	}
+	if !d.enableIPv6 {
+		opts = append(opts, "--ipv4-only")
+	}
+	if d.implicitPortForwarding {
+		opts = append(opts, "--tcp-ports=auto",
+			"--udp-ports=auto")
+		// TCP ports are periodically watched, but UDP ports are not.
+	} else {
+		opts = append(opts, "--tcp-ports=none",
+			"--udp-ports=none")
+	}
+	if detachedNetNSPath == "" {
+		opts = append(opts, strconv.Itoa(childPID))
+	} else {
+		opts = append(opts,
+			fmt.Sprintf("--userns=/proc/%d/ns/user", childPID),
+			"--netns="+detachedNetNSPath)
+	}
+
+	// FIXME: Doesn't work with passt_0.0~git20230216.4663ccc-1_amd64.deb (Ubuntu 23.04)
+	// `Couldn't open user namespace /proc/51813/ns/user: Permission denied`
+	// Possibly related to AppArmor.
+	cmd := exec.Command(d.binary, opts...)
+	cmd.Stdout = d.logWriter
+	cmd.Stderr = d.logWriter
+	cleanups = append(cleanups, func() error {
+		logrus.Debugf("killing pasta")
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		wErr := cmd.Wait()
+		logrus.Debugf("killed pasta: %v", wErr)
+		return nil
+	})
+	if err := cmd.Start(); err != nil {
+		return nil, common.Seq(cleanups), fmt.Errorf("executing %v: %w", cmd, err)
+	}
+	netmsg := messages.ParentInitNetworkDriverCompleted{
+		Dev: tap,
+		MTU: d.mtu,
+	}
+	netmsg.IP = address.String()
+	netmsg.Netmask = netmask
+	netmsg.Gateway = gateway.String()
+	netmsg.DNS = dns.String()
+
+	d.infoMu.Lock()
+	d.info = func() *api.NetworkDriverInfo {
+		return &api.NetworkDriverInfo{
+			Driver:         DriverName,
+			DNS:            []net.IP{net.ParseIP(netmsg.DNS)},
+			ChildIP:        net.ParseIP(netmsg.IP),
+			DynamicChildIP: false,
+		}
+	}
+	d.infoMu.Unlock()
+	return &netmsg, common.Seq(cleanups), nil
+}
+
+func NewChildDriver() network.ChildDriver {
+	return &childDriver{}
+}
+
+type childDriver struct {
+}
+
+func (d *childDriver) ConfigureNetworkChild(netmsg *messages.ParentInitNetworkDriverCompleted, detachedNetNSPath string) (string, error) {
+	// NOP
+	return netmsg.Dev, nil
+}


### PR DESCRIPTION
Pasta: https://passt.top/passt/
Usage: `rootlesskit --net=pasta --port-driver=implicit`

- No support for explicit port forwarding (`rootlessctl add-ports`),
  as pasta doesn't support it yet.
  Use `--port-driver=implicit` to let pasta forward TCP ports implicitly.
  The forwarded ports are not visible in `rootlessctl list-ports`.

- No support for forwarding UDP ports

- Tested with pasta 2023_06_25.32660ce on Ubuntu 23.04.
  Doesn't work with 2023_06_03.429e1a7: `Option --no-copy-routes needs --config-net`
  (This is printed despite that `--no-copy-routes` is not specified)

- Doesn't work with Ubuntu 23.04's dpkg (passt_0.0~git20230216.4663ccc-1_amd64.deb):
  `Couldn't open user namespace /proc/51813/ns/user: Permission denied`
  Likely to be related to AppArmor.
  `sudo apparmor_parser -R /etc/apparmor.d/usr.bin.passt` can eliminate this error, but pasta still fails with another error ( `Couldn't get any nameserver address`)