### PR TITLE
Remove duplicate id ranges returned by getsubu/gid for username/uid

### DIFF
--- a/pkg/parent/dynidtools/dynidtools.go
+++ b/pkg/parent/dynidtools/dynidtools.go
@@ -14,6 +14,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func withoutDuplicates(sliceList []idtools.SubIDRange) []idtools.SubIDRange {
+	seenKeys := make(map[idtools.SubIDRange]bool)
+	var list []idtools.SubIDRange
+	for _, item := range sliceList {
+		if _, value := seenKeys[item]; !value {
+			seenKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
 func GetSubIDRanges(uid int, username string) ([]idtools.SubIDRange, []idtools.SubIDRange, error) {
 	getsubidsExeName := "getsubids"
 	if v := os.Getenv("GETSUBIDS"); v != "" {
@@ -52,8 +64,8 @@ func GetSubIDRanges(uid int, username string) ([]idtools.SubIDRange, []idtools.S
 		}
 	}
 
-	u := append(uByUsername, uByUID...)
-	g := append(gByUsername, gByUID...)
+	u := withoutDuplicates(append(uByUsername, uByUID...))
+	g := withoutDuplicates(append(gByUsername, gByUID...))
 	return u, g, nil
 }
 


### PR DESCRIPTION
In LDAP-based environments both `getsubids myusername` and `getsubids 1234` (where `id myusername` equals to `1234`) can return exactly the same subuid ranges. This happens when one of `/etc/subuid` or `nss` returns mappings for both the user id and the user name. Both `newgidmap` and `newuidmap` fail when the parameters contain duplicate ranges.

This PR fixes the problem by removing duplicates from the list of subid mappings in `dynidtools`.
`idtools` (`/etc/subuid` handling) is left untouched.
