### PR TITLE
feat: add new bridge network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ all: $(addprefix bin/, $(BINARIES))
 clean:
 	$(RM) -r bin/ _artifact/
 
+bin/rootlesskit-debug: $(GO_FILES)
+	$(GO) build -o $@ -gcflags="all=-N -l" -v ./cmd/rootlesskit
+
 bin/rootlesskit: $(GO_FILES)
 	$(GO) build -o $@ -v ./cmd/rootlesskit
 

--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/v2/pkg/network/pasta"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/network/slirp4netns"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/network/vpnkit"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/network/bridge"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/parent"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/port/builtin"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/port/portutil"
@@ -83,7 +84,7 @@ See https://rootlesscontaine.rs/getting-started/common/ .
 		}, CategoryState),
 		Categorize(&cli.StringFlag{
 			Name:  "net",
-			Usage: "network driver [host, pasta(experimental), slirp4netns, vpnkit, lxc-user-nic(experimental)]",
+			Usage: "network driver [host, bridge, pasta(experimental), slirp4netns, vpnkit, lxc-user-nic(experimental)]",
 			Value: "host",
 		}, CategoryNetwork),
 		Categorize(&cli.StringFlag{
@@ -388,6 +389,11 @@ func createParentOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey, pare
 		if ifname != "" {
 			return opt, errors.New("ifname cannot be specified for --net=host")
 		}
+	case "bridge":
+		opt.NetworkDriver, err = bridge.NewParentDriver(mtu, ipnet, ifname)
+		if err != nil {
+			return opt, err
+		}
 	case "pasta":
 		logrus.Warn("\"pasta\" network driver is experimental. Needs very recent version of pasta (see docs/network.md).")
 		binary := clicontext.String("pasta-binary")
@@ -582,6 +588,8 @@ func createChildOpt(clicontext *cli.Context, pipeFDEnvKey, stateDirEnvKey string
 	switch s := clicontext.String("net"); s {
 	case "host":
 		// NOP
+	case "bridge":
+		opt.NetworkDriver = bridge.NewChildDriver()
 	case "pasta":
 		opt.NetworkDriver = pasta.NewChildDriver()
 	case "slirp4netns":

--- a/pkg/network/bridge/bridge.go
+++ b/pkg/network/bridge/bridge.go
@@ -1,0 +1,164 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/rootless-containers/rootlesskit/v2/pkg/api"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/messages"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/network"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/network/iputils"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/network/parentutils"
+)
+
+func getLocalNameserver() (nameserver string) {
+	ns := "1.1.1.1"
+	data, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return ns
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] != "nameserver" {
+			continue
+		}
+		for _, field := range fields[1:] {
+			ip, err := netip.ParseAddr(field)
+			if err != nil {
+				continue
+			}
+			ns = ip.String()
+			break
+		}
+	}
+
+	return ns
+}
+
+func NewParentDriver(mtu int, ipnet *net.IPNet, ifname string) (network.ParentDriver, error) {
+	if mtu < 0 {
+		panic("got negative mtu")
+	}
+	if mtu == 0 {
+		mtu = 1500
+	}
+	if ifname == "" {
+		ifname = "bridge0"
+	}
+	if ipnet == nil {
+		var err error
+		_, ipnet, err = net.ParseCIDR("172.17.0.0/16")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &parentDriver{
+		mtu:    mtu,
+		ipnet:  ipnet,
+		ifname: ifname,
+	}, nil
+
+}
+
+type parentDriver struct {
+	mtu       int
+	ifname    string
+	ipnet     *net.IPNet
+	infoMu    sync.RWMutex
+	info      func() *api.NetworkDriverInfo
+}
+
+const DriverName = "bridge"
+
+func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error) {
+	d.infoMu.RLock()
+	infoFn := d.info
+	d.infoMu.RUnlock()
+	if infoFn == nil {
+		return &api.NetworkDriverInfo{
+			Driver: DriverName,
+		}, nil
+	}
+
+	return infoFn(), nil
+}
+
+func (d *parentDriver) MTU() int {
+	return d.mtu
+}
+
+func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPath string) (*messages.ParentInitNetworkDriverCompleted, func() error, error) {
+	bridge := d.ifname
+	var cleanups []func() error
+	address, err := iputils.AddIPInt(d.ipnet.IP, 2)
+	if err != nil {
+		return nil, common.Seq(cleanups), err
+	}
+	netmask, _ := d.ipnet.Mask.Size()
+	gateway, err := iputils.AddIPInt(d.ipnet.IP, 1)
+	if err != nil {
+		return nil, common.Seq(cleanups), err
+	}
+
+	ipnet := &net.IPNet{IP: address, Mask: d.ipnet.Mask}
+	if err := parentutils.PrepareBridge(childPID, detachedNetNSPath, bridge, ipnet.String(), gateway.String()); err != nil {
+		return nil, common.Seq(cleanups), fmt.Errorf("setting up interface %s: %w", bridge, err)
+	}
+
+	if detachedNetNSPath != "" {
+		cmd := exec.Command("nsenter", "-t", strconv.Itoa(childPID), "-n"+detachedNetNSPath, "--no-fork", "-m", "-U", "--preserve-credentials", "sleep", "infinity")
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGKILL,
+		}
+		err := cmd.Start()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	netmsg := messages.ParentInitNetworkDriverCompleted{
+		Dev: bridge,
+		DNS: getLocalNameserver(),
+		MTU: d.mtu,
+	}
+	netmsg.IP = address.String()
+	netmsg.Netmask = netmask
+	netmsg.Gateway = gateway.String()
+
+	d.infoMu.Lock()
+	d.info = func() *api.NetworkDriverInfo {
+		return &api.NetworkDriverInfo{
+			Driver:         DriverName,
+			ChildIP:        net.ParseIP(netmsg.IP),
+			DynamicChildIP: false,
+		}
+	}
+	d.infoMu.Unlock()
+	return &netmsg, common.Seq(cleanups), nil
+}
+
+func NewChildDriver() network.ChildDriver {
+	return &childDriver{}
+}
+
+type childDriver struct {
+}
+
+func (d *childDriver) ConfigureNetworkChild(netmsg *messages.ParentInitNetworkDriverCompleted, detachedNetNSPath string) (string, error) {
+	return netmsg.Dev, nil
+}

--- a/pkg/network/parentutils/parentutils.go
+++ b/pkg/network/parentutils/parentutils.go
@@ -19,6 +19,17 @@ func PrepareTap(childPID int, childNetNsPath string, tap string) error {
 	return nil
 }
 
+func PrepareBridge(childPID int, childNetNsPath string, ifname string, ipnet string, ipgw string) error {
+	cmds := [][]string{
+		nsenter(childPID, childNetNsPath, []string{"ip", "link", "add", ifname, "type", "bridge"}),
+		nsenter(childPID, childNetNsPath, []string{"ip", "link", "set", ifname, "up"}),
+	}
+	if err := common.Execs(os.Stderr, os.Environ(), cmds); err != nil {
+		return fmt.Errorf("executing %v: %w", cmds, err)
+	}
+	return nil
+}
+
 func nsenter(childPID int, childNetNsPath string, cmd []string) []string {
 	fullCmd := []string{"nsenter", "-t", strconv.Itoa(childPID)}
 	if childNetNsPath != "" {


### PR DESCRIPTION
This PR will add net `bridge` driver support. The driver almost similar with `lxc-user-nic` but without attaching connectivity between host namespace with target namespace. The connectivity need to be configured manually with the help `veth` interface (need root privilege) from host namespace which can be "watched" using `bash` script +  `systemd` service.

eg.
```bash
#!/usr/bin/env bash

export ROOTKIT_STATE_DIRECTORY=/path/to/rootkit/state/directory
export BRIDGE=docker0
export VETHP=docker0p1
export VETHC=docker0c1

# add masquerade support
echo 1 > /proc/sys/net/ipv4/ip_forward
iptables-save | grep -q ${BRIDGE} || iptables -t nat -A POSTROUTING -s 172.17.0.0/16 ! -o ${BRIDGE} -j MASQUERADE

while :; do
  until test -r ${ROOTKIT_STATE_DIRECTORY}/child_pid; do
    sleep 1
  done

  child_pid=$(cat ${ROOTKIT_STATE_DIRECTORY}/child_pid)
  mkdir -p /var/run/netns
  ln -sf /proc/${child_pid}/ns/net /var/run/netns/${BRIDGE}
  ip link add ${VETHC} type veth peer name ${VETHP}
  ip link set ${VETHP} up
  ip link set ${VETHP} master ${BRIDGE}
  ip link set ${VETHC} netns ${BRIDGE}

  while test -r ${ROOTKIT_STATE_DIRECTORY}/child_pid && ip link show ${VETHP} &>/dev/null; do
    sleep 1
  done
done
```