### PR TITLE
Fix DNS not being accessible with slirp4netns on hosts with IPv6-only nameservers

### DIFF
--- a/pkg/child/resolvconf.go
+++ b/pkg/child/resolvconf.go
@@ -1,5 +1,12 @@
 package child
 
-func generateResolvConf(dns string) []byte {
-	return []byte("nameserver " + dns + "\n")
+import "strings"
+
+func generateResolvConf(dns []string) []byte {
+	var sb strings.Builder
+
+	for _, nameserver := range dns {
+		sb.WriteString("nameserver " + nameserver + "\n")
+	}
+	return []byte(sb.String())
 }

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -59,7 +59,7 @@ type ParentInitNetworkDriverCompleted struct {
 	IP      string
 	Netmask int
 	Gateway string
-	DNS     string
+	DNS     []string
 	MTU     int
 	// NetworkDriverOpaque strings are specific to driver
 	NetworkDriverOpaque map[string]string

--- a/pkg/network/lxcusernic/lxcusernic.go
+++ b/pkg/network/lxcusernic/lxcusernic.go
@@ -184,7 +184,7 @@ func (d *childDriver) ConfigureNetworkChild(netmsg *messages.ParentInitNetworkDr
 	netmask, _ := p.SubnetMask().Size()
 	netmsg.Netmask = netmask
 	netmsg.Gateway = p.Router()[0].To4().String()
-	netmsg.DNS = p.DNS()[0].To4().String()
+	netmsg.DNS = []string{p.DNS()[0].To4().String()}
 	go dhcpRenewRoutine(c, dev, p.YourIPAddr.To4(), p.IPAddressLeaseTime(time.Hour), detachedNetNSPath)
 	return dev, nil
 }

--- a/pkg/network/pasta/pasta.go
+++ b/pkg/network/pasta/pasta.go
@@ -169,13 +169,13 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 	netmsg.IP = address.String()
 	netmsg.Netmask = netmask
 	netmsg.Gateway = gateway.String()
-	netmsg.DNS = dns.String()
+	netmsg.DNS = []string{dns.String()}
 
 	d.infoMu.Lock()
 	d.info = func() *api.NetworkDriverInfo {
 		return &api.NetworkDriverInfo{
 			Driver:         DriverName,
-			DNS:            []net.IP{net.ParseIP(netmsg.DNS)},
+			DNS:            []net.IP{net.ParseIP(netmsg.DNS[0])},
 			ChildIP:        net.ParseIP(netmsg.IP),
 			DynamicChildIP: false,
 		}

--- a/pkg/network/slirp4netns/slirp4netns.go
+++ b/pkg/network/slirp4netns/slirp4netns.go
@@ -271,6 +271,12 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 		netmsg.DNS = append(netmsg.DNS, "10.0.2.3")
 	}
 
+	if d.enableIPv6 {
+		// for now slirp4netns only supports fd00::3 as v6 nameserver
+		// https://github.com/rootless-containers/slirp4netns/blob/ee1542e1532e6a7f266b8b6118973ab3b10a8bb5/slirp4netns.c#L272
+		netmsg.DNS = append(netmsg.DNS, "fd00::3")
+	}
+
 	apiDNS := make([]net.IP, 0, cap(netmsg.DNS))
 	for _, nameserver := range netmsg.DNS {
 		apiDNS = append(apiDNS, net.ParseIP(nameserver))

--- a/pkg/network/vpnkit/vpnkit.go
+++ b/pkg/network/vpnkit/vpnkit.go
@@ -127,7 +127,7 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 		IP:      vif.IP.String(),
 		Netmask: 24,
 		Gateway: "192.168.65.1",
-		DNS:     "192.168.65.1",
+		DNS:     []string{"192.168.65.1"},
 		MTU:     d.mtu,
 		NetworkDriverOpaque: map[string]string{
 			opaqueMAC:    vif.ClientMAC.String(),
@@ -139,7 +139,7 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 	d.info = func() *api.NetworkDriverInfo {
 		return &api.NetworkDriverInfo{
 			Driver:         DriverName,
-			DNS:            []net.IP{net.ParseIP(netmsg.DNS)},
+			DNS:            []net.IP{net.ParseIP(netmsg.DNS[0])},
 			ChildIP:        net.ParseIP(netmsg.IP),
 			DynamicChildIP: false,
 		}


### PR DESCRIPTION
libslirp will provide DNS to the "guest side" simply by forwarding IPv4 UDP packets to the IPv4 host nameserver and idem for IPv6.

See https://gitlab.freedesktop.org/slirp/libslirp/-/blob/6ea2c4f95922a64d21190d9ad163e3bbde37a836/src/socket.c#L971
and https://gitlab.freedesktop.org/slirp/libslirp/-/blob/6ea2c4f95922a64d21190d9ad163e3bbde37a836/src/socket.c#L990

On a host with only IPv4 or IPv6 nameservers this will make only `10.0.2.3` or `fd00::3` functional.
This PR will fix DNS issues on hosts with only IPv6 DNS (such as on a network using NAT64 and DNS64 without client-side address translation) by advertising to the child process the Slirp IPv6 DNS address.