### PR TITLE
Add execution branch for socket activation to correct LISTEN_PID

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,8 @@ jobs:
       run: docker run --rm --net=host --privileged rootlesskit:test-integration ./integration-port.sh
     - name: "Integration test: IPv6 routing"
       run: docker run  --rm --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 rootlesskit:test-integration ./integration-ipv6.sh
+    - name: "Integration test: systemd socket activation"
+      run: docker run --rm --net=none --privileged rootlesskit:test-integration ./integration-systemd-socket.sh
     - name: "Integration test: Network (network driver=slirp4netns)"
       run: |
         docker run --rm --privileged rootlesskit:test-integration ./integration-net.sh slirp4netns

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ FROM ubuntu:${UBUNTU_VERSION} AS test-integration
 # sudo: only for lxc-user-nic benchmark and rootful veth benchmark (for comparison)
 # libcap2-bin and curl: used by the RUN instructions in this Dockerfile.
 # bind9-dnsutils: for `nslookup` command used by integration-net.sh
-RUN apt-get update && apt-get install -y iproute2 liblxc-common lxc-utils iperf3 busybox sudo libcap2-bin curl bind9-dnsutils
+# systemd and uuid-runtime: for systemd-socket-activate used by integration-systemd-socket.sh
+RUN apt-get update && apt-get install -y iproute2 liblxc-common lxc-utils iperf3 busybox sudo libcap2-bin curl bind9-dnsutils systemd uuid-runtime
 COPY --from=idmap /usr/bin/newuidmap /usr/bin/newuidmap
 COPY --from=idmap /usr/bin/newgidmap /usr/bin/newgidmap
 RUN /sbin/setcap cap_setuid+eip /usr/bin/newuidmap && \

--- a/hack/integration-systemd-socket-check-env.sh
+++ b/hack/integration-systemd-socket-check-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+OK_FILE=$1
+ERR_FILE=$2
+EXPECTED_LISTEN_FDS=$3
+
+fail() {
+  echo "$@" > "$ERR_FILE"
+  exit 1
+}
+
+if ! [[ "${LISTEN_FDS:-}" =~ [1-9] ]]; then
+  fail "LISTEN_FDS (${LISTEN_FDS:-}) is not set or not positive a number."
+fi
+
+if [[ "${LISTEN_FDS:-}" != "${EXPECTED_LISTEN_FDS}" ]]; then
+  fail "LISTEN_FDS (${LISTEN_FDS}) is not equal to expected ${EXPECTED_LISTEN_FDS}."
+fi
+
+if [[ "${LISTEN_PID}" != "$$" ]]; then
+  fail "LISTEN_PID (${LISTEN_PID}) is not equal to \$\$ ($$)."
+fi
+
+for ((i=0,fdnum=3; i<LISTEN_FDS; fdnum++, i++)); do
+  fdpath="/proc/$$/fd/${fdnum}"
+  if [[ ! -e "$fdpath" ]]; then
+    fail "FD #${fdnum} does not exists"
+  fi
+done
+
+touch "${OK_FILE}"

--- a/hack/integration-systemd-socket.sh
+++ b/hack/integration-systemd-socket.sh
@@ -1,17 +1,55 @@
-#!/bin/sh
-set -e
-if [ -z "$EXECED" ]
-then
-	systemd-socket-activate -E EXECED=1 -l /tmp/activate.sock socat ACCEPT-FD:3 EXEC:"rootlesskit $0",nofork 2>/dev/null &
-	OUTPUT="$(curl --unix-socket /tmp/activate.sock http://localhost/hello 2>/dev/null)"
-	[ "$(printf 'Hello\n' )" = "$OUTPUT" ] || exit 1
-else
-	[ "$LISTEN_FDS" = "1" ] || exit 1
-	read -r REQUEST
-	if [ "$(printf 'GET /hello HTTP/1.1\r\n')" = "$REQUEST" ]
-	then
-	    printf 'HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nHello\n'
-	else
-	    printf 'HTTP/1.1 400 Bad Request\r\nContent-Length: 5\r\n\r\nBad!\n'
-	fi
-fi
+#!/bin/bash
+
+srcdir=$(realpath $(dirname $0))
+source "${srcdir}/common.inc.sh"
+
+test_with_uuidd_daemon() {
+    uuidd_tmpdir=$(mktemp -d)
+    uuidd_sock="${uuidd_tmpdir}/uuidd.sock"
+    systemd-socket-activate -l "${uuidd_sock}" "$ROOTLESSKIT" uuidd --no-pid --no-fork --socket-activation &
+    pid=$!
+    sleep 2
+    uuidd -d -r -n 1 -s "${uuidd_sock}" || return 1
+    uuidd -d -t -n 1 -s "${uuidd_sock}" || return 1
+    uuidd -d -k -s "${uuidd_sock}" || return 1
+    rm -r "${uuidd_tmpdir}" || return 1
+    wait $pid || return 1
+}
+
+test_env_variables() {
+   tmpdir=$(mktemp -d)
+   sock1="${tmpdir}/sock1.sock"
+   sock2="${tmpdir}/sock2.sock"
+   sock3="${tmpdir}/sock3.sock"
+   ## Test 1 socket
+   timeout 30 systemd-socket-activate -l "${sock1}" "$ROOTLESSKIT" "${srcdir}/integration-systemd-socket-check-env.sh" "${tmpdir}/ok1" "${tmpdir}/fail1" 1 &
+   pid=$!
+   sleep 2
+   curl --unix-socket "${sock1}" "http//example.com" >/dev/null 2>&1 || true # just trigger
+   wait $pid
+   if [[ ! -e "${tmpdir}/ok1" ]]; then return 1; fi
+   ## Test 2 sockets
+   timeout 30 systemd-socket-activate -l "${sock1}" -l "${sock2}" "$ROOTLESSKIT" "${srcdir}/integration-systemd-socket-check-env.sh" "${tmpdir}/ok2" "${tmpdir}/fail2" 2 &
+   pid=$!
+   sleep 2
+   curl --unix-socket "${sock1}" "http//example.com" >/dev/null 2>&1 || true
+   wait $pid
+   if [[ ! -e "${tmpdir}/ok2" ]]; then return 1; fi
+   ## Test 3 sockets
+   timeout 30 systemd-socket-activate -l "${sock1}" -l "${sock2}" -l "${sock3}" "$ROOTLESSKIT" "${srcdir}/integration-systemd-socket-check-env.sh" "${tmpdir}/ok3" "${tmpdir}/fail3" 3 &
+   pid=$!
+   sleep 2
+   curl --unix-socket "${sock1}" "http//example.com" >/dev/null 2>&1 || true
+   wait $pid
+   if [[ ! -e "${tmpdir}/ok3" ]]; then return 1; fi
+
+   rm -r "${tmpdir}"
+}
+
+INFO "===== Systemd socket activation: uuidd daemon ====="
+test_with_uuidd_daemon
+
+INFO "===== Systemd socket activation: LISTEN_* variables check ====="
+test_env_variables
+
+INFO "===== PASSING ====="

--- a/pkg/systemd/activation/activation.go
+++ b/pkg/systemd/activation/activation.go
@@ -1,0 +1,28 @@
+package activation
+
+import (
+  "os"
+  "os/exec"
+  "syscall"
+  "strconv"
+)
+
+type Opt struct {
+  RunActivationHelperEnvKey  string   // needs to be set
+  TargetCmd                  []string // needs to be set
+}
+
+func ActivationHelper(opt Opt) error {
+  pid := os.Getpid()
+  os.Unsetenv(opt.RunActivationHelperEnvKey)
+  os.Setenv("LISTEN_PID", strconv.Itoa(pid))
+  argsv := opt.TargetCmd
+  execPath, err := exec.LookPath(argsv[0])
+  if err != nil {
+    return err
+  }
+  if err = syscall.Exec(execPath, argsv, os.Environ()); err != nil {
+    return err
+  }
+  panic("should not reach here")
+}


### PR DESCRIPTION
Proposal on https://github.com/rootless-containers/rootlesskit/issues/448
Fixing LISTEN_PID env variable for target process if it equals to PID of [rootlless:parent] process.

Tested with dockerd. Extra $$ script is not required anymore.
```Shell
systemd-socket-activate -E "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" -l 12312 \
./rootlesskit/rootlesskit --net=slirp4netns --slirp4netns-sandbox=true \
--slirp4netns-seccomp=true \
--disable-host-loopback \
--port-driver=slirp4netns \
--copy-up=/etc \
--copy-up=/run \
sh -c 'rm /run/docker ; exec dockerd -H fd://'
```

Can be demonstated.
```Shell 
> (timeout 10 systemd-socket-activate -l 12345 ./rootlesskit --pidns sh -c 'echo "\$\$ is $$; LISTEN_PID is $LISTEN_PID"' &); sleep 1; netcat localhost 12345
Listening on [::]:12345 as 3.
Communication attempt on fd 3.
Execing ./rootlesskit (./rootlesskit --pidns sh -c echo "\$\$ is $$; LISTEN_PID is $LISTEN_PID")
$$ is 11; LISTEN_PID is 11
```

Example output for v2.1.0:
```Shell
(timeout 10 systemd-socket-activate -l 12345 ./rootlesskit --pidns sh -c 'echo "\$\$ is $$; LISTEN_PID is $LISTEN_PID"' &); sleep 1; netcat localhost 12345
Listening on [::]:12345 as 3.
Communication attempt on fd 3.
Execing ./rootlesskit (./rootlesskit --pidns sh -c echo "\$\$ is $$; LISTEN_PID is $LISTEN_PID")
$$ is 11; LISTEN_PID is 3868868
```