### PR TITLE
Deprecate rootlesskit-docker-proxy (no longer needed since Docker v28)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ bin/rootlessctl: $(GO_FILES)
 	$(GO) build -o $@ -v ./cmd/rootlessctl
 
 bin/rootlesskit-docker-proxy: $(GO_FILES)
+	@echo "NOTE: rootlesskit-docker-proxy is required only if you use Docker prior to v28."
+	@echo "NOTE: rootlesskit-docker-proxy is DEPRECATED and will be removed in RootlessKit v3."
 	$(GO) build -o $@ -v ./cmd/rootlesskit-docker-proxy
 
 .PHONY: cross

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run `make && sudo make install` .
 The following binaries will be installed:
 - `/usr/local/bin/rootlesskit`
 - `/usr/local/bin/rootlessctl`
-- `/usr/local/bin/rootlesskit-docker-proxy` (Can be safely removed if you do not use Docker)
+- `/usr/local/bin/rootlesskit-docker-proxy` (DEPRECATED; Only required for Docker prior to [v28](https://github.com/moby/moby/pull/48132/commits/dac7ffa3404138a4f291c16586e5a2c68dad4151))
 
 ### Requirements
 

--- a/cmd/rootlesskit-docker-proxy/main.go
+++ b/cmd/rootlesskit-docker-proxy/main.go
@@ -1,3 +1,12 @@
+// Package main provides the `rootlesskit-docker-proxy` binary (DEPRECATED)
+// that was used by Docker prior to v28 for supporting rootless mode.
+//
+// The rootlesskit-docker-proxy binary is no longer needed since Docker v28,
+// as the functionality of rootlesskit-docker-proxy is now provided by dockerd itself.
+//
+// https://github.com/moby/moby/pull/48132/commits/dac7ffa3404138a4f291c16586e5a2c68dad4151
+//
+// rootlesskit-docker-proxy will be removed in RootlessKit v3.
 package main
 
 import (


### PR DESCRIPTION
The rootlesskit-docker-proxy binary is no longer needed since Docker v28, as the functionality of rootlesskit-docker-proxy is now provided by dockerd itself.

https://github.com/moby/moby/pull/48132/commits/dac7ffa3404138a4f291c16586e5a2c68dad4151

rootlesskit-docker-proxy will be removed in RootlessKit v3.