### PR TITLE
Update comment and network guide to reflect current status of pasta's AppArmor issue on Ubuntu

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -147,6 +147,18 @@ If `--disable-host-loopback` is not specified, ports listening on 127.0.0.1 in t
 > **Note**
 > `--net=pasta` needs [pasta (passt)](https://passt.top/passt/) `2023_06_25.32660ce` or later.
 > Using `2023_12_04.b86afe3` or later is highly recommended.
+>
+> Currently, this doesn't work with some Ubuntu versions of the passt
+> package:
+> - `passt-0.0~git20230627.289301b-1` (Ubuntu 23.10)
+> - `passt-0.0~git20240220.1e6f92b-1` (Ubuntu 24.04)
+> due to a missing `usr.bin.pasta` AppArmor profile, see:
+> https://bugs.launchpad.net/ubuntu/+source/passt/+bug/2077158
+>
+> Workaround: set the `kernel.apparmor_restrict_unprivileged_userns`
+> sysctl to `0`, or (preferred) add the AppArmor profile from
+> upstream, or from Debian packages, or from Ubuntu > 24.10.
+
 
 Pros:
 * Possible to perform network-namespaced operations, e.g. creating iptables rules, running `tcpdump`

--- a/docs/network.md
+++ b/docs/network.md
@@ -147,9 +147,6 @@ If `--disable-host-loopback` is not specified, ports listening on 127.0.0.1 in t
 > **Note**
 > `--net=pasta` needs [pasta (passt)](https://passt.top/passt/) `2023_06_25.32660ce` or later.
 > Using `2023_12_04.b86afe3` or later is highly recommended.
->
-> Depending on the version of pasta and the host operating system,
-> running `sudo apparmor_parser -R /etc/apparmor.d/usr.bin.passt` might be needed too.
 
 Pros:
 * Possible to perform network-namespaced operations, e.g. creating iptables rules, running `tcpdump`

--- a/pkg/network/pasta/pasta.go
+++ b/pkg/network/pasta/pasta.go
@@ -137,9 +137,14 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 			"--netns="+detachedNetNSPath)
 	}
 
-	// FIXME: Doesn't work with passt_0.0~git20230216.4663ccc-1_amd64.deb (Ubuntu 23.04)
-	// `Couldn't open user namespace /proc/51813/ns/user: Permission denied`
-	// Possibly related to AppArmor.
+	// FIXME: Doesn't work with:
+	// - passt-0.0~git20230627.289301b-1 (Ubuntu 23.10)
+	// - passt-0.0~git20240220.1e6f92b-1 (Ubuntu 24.04)
+	// see https://bugs.launchpad.net/ubuntu/+source/passt/+bug/2077158
+	//
+	// Workaround: set the kernel.apparmor_restrict_unprivileged_userns
+	// sysctl to 0, or (preferred) add the AppArmor profile from upstream,
+	// or from Debian packages, or from Ubuntu > 24.10.
 	cmd := exec.Command(d.binary, opts...)
 	logrus.Debugf("Executing %v", cmd.Args)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
As suggested in https://github.com/rootless-containers/rootlesskit/pull/458#pullrequestreview-2242422678