### PR TITLE
port/builtin: return proper error for sctp

### DIFF
--- a/pkg/port/builtin/parent/parent.go
+++ b/pkg/port/builtin/parent/parent.go
@@ -159,8 +159,7 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	case "udp", "udp4", "udp6":
 		err = udp.Run(d.socketPath, spec, routineStopCh, routineStoppedCh, d.logWriter)
 	default:
-		// NOTREACHED
-		return nil, errors.New("spec was not validated?")
+		return nil, fmt.Errorf("unsupported port protocol %s", spec.Proto)
 	}
 	if err != nil {
 		if isEPERM(err) {


### PR DESCRIPTION
When trying to forward sctp port we get a useless
"rootlessport spec was not validated" error back even though the spec was validated before. It is not clear to me if other drivers support sctp here so I didn't want to change ValidatePortSpec to disallow sctp.

As such simply return a useful error saying the protocol is not supported.