### PR TITLE
Fix detach-netns permission error on Ubuntu 25.04

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -171,6 +171,11 @@ See https://rootlesscontaine.rs/getting-started/common/ .
 			Usage:   "publish ports. e.g. \"127.0.0.1:8080:80/tcp\"",
 		}, CategoryPort),
 		Categorize(&cli.BoolFlag{
+			Name:  "userns",
+			Usage: "create a User namespace (Usually this should be always set to true)",
+			Value: true,
+		}, CategoryProcess),
+		Categorize(&cli.BoolFlag{
 			Name:  "pidns",
 			Usage: "create a PID namespace",
 		}, CategoryProcess),
@@ -325,6 +330,7 @@ func createParentOpt(clicontext *cli.Context) (parent.Opt, error) {
 		PipeFDEnvKey:             pipeFDEnvKey,
 		StateDirEnvKey:           stateDirEnvKey,
 		ChildUseActivationEnvKey: childUseActivationEnvKey,
+		NoCreateUserNS:           !clicontext.Bool("userns"),
 		CreatePIDNS:              clicontext.Bool("pidns"),
 		CreateCgroupNS:           clicontext.Bool("cgroupns"),
 		CreateUTSNS:              clicontext.Bool("utsns"),
@@ -603,6 +609,7 @@ func createChildOpt(clicontext *cli.Context) (child.Opt, error) {
 		DetachNetNS:               detachNetNS,
 		Propagation:               clicontext.String("propagation"),
 		EvacuateCgroup2:           clicontext.String("evacuate-cgroup2") != "",
+		NoCreateUserNS:            !clicontext.Bool("userns"),
 	}
 	switch reaperStr := clicontext.String("reaper"); reaperStr {
 	case "auto":

--- a/pkg/network/none/none.go
+++ b/pkg/network/none/none.go
@@ -3,14 +3,12 @@ package none
 import (
 	"context"
 	"os"
-	"os/exec"
-	"strconv"
-	"syscall"
 
 	"github.com/rootless-containers/rootlesskit/v2/pkg/api"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/messages"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/network"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/network/parentutils"
 )
 
 func NewParentDriver() (network.ParentDriver, error) {
@@ -35,21 +33,15 @@ func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPath string) (*messages.ParentInitNetworkDriverCompleted, func() error, error) {
 	var cleanups []func() error
 
-	if detachedNetNSPath != "" {
-		cmd := exec.Command("nsenter", "-t", strconv.Itoa(childPID), "-n"+detachedNetNSPath, "-m", "-U", "--no-fork", "--preserve-credentials", "sleep", "infinity")
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Pdeathsig: syscall.SIGKILL,
-		}
-		err := cmd.Start()
-		if err != nil {
-			return nil, nil, err
-		}
-		childPID = cmd.Process.Pid
+	sameUserNSAsCurrent, err := parentutils.SameUserNSAsCurrent(childPID)
+	if err != nil {
+		return nil, nil, err
 	}
+	userns := !sameUserNSAsCurrent
 
 	cmds := [][]string{
-		[]string{"nsenter", "-t", strconv.Itoa(childPID), "-n", "-m", "-U", "--no-fork", "--preserve-credentials", "ip", "address", "add", "127.0.0.1/8", "dev", "lo"},
-		[]string{"nsenter", "-t", strconv.Itoa(childPID), "-n", "-m", "-U", "--no-fork", "--preserve-credentials", "ip", "link", "set", "lo", "up"},
+		parentutils.NSEnter(childPID, detachedNetNSPath, userns, []string{"ip", "address", "add", "127.0.0.1/8", "dev", "lo"}),
+		parentutils.NSEnter(childPID, detachedNetNSPath, userns, []string{"ip", "link", "set", "lo", "up"}),
 	}
 	if err := common.Execs(os.Stderr, os.Environ(), cmds); err != nil {
 		return nil, nil, err

--- a/pkg/network/parentutils/parentutils.go
+++ b/pkg/network/parentutils/parentutils.go
@@ -3,15 +3,21 @@ package parentutils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
 )
 
 func PrepareTap(childPID int, childNetNsPath string, tap string) error {
+	sameUserNSAsCurrent, err := SameUserNSAsCurrent(childPID)
+	if err != nil {
+		return err
+	}
+	userns := !sameUserNSAsCurrent
 	cmds := [][]string{
-		nsenter(childPID, childNetNsPath, []string{"ip", "tuntap", "add", "name", tap, "mode", "tap"}),
-		nsenter(childPID, childNetNsPath, []string{"ip", "link", "set", tap, "up"}),
+		NSEnter(childPID, childNetNsPath, userns, []string{"ip", "tuntap", "add", "name", tap, "mode", "tap"}),
+		NSEnter(childPID, childNetNsPath, userns, []string{"ip", "link", "set", tap, "up"}),
 	}
 	if err := common.Execs(os.Stderr, os.Environ(), cmds); err != nil {
 		return fmt.Errorf("executing %v: %w", cmds, err)
@@ -19,14 +25,34 @@ func PrepareTap(childPID int, childNetNsPath string, tap string) error {
 	return nil
 }
 
-func nsenter(childPID int, childNetNsPath string, cmd []string) []string {
+func NSEnter(childPID int, childNetNsPath string, userns bool, cmd []string) []string {
 	fullCmd := []string{"nsenter", "-t", strconv.Itoa(childPID)}
 	if childNetNsPath != "" {
 		fullCmd = append(fullCmd, "-n"+childNetNsPath)
 	} else {
 		fullCmd = append(fullCmd, "-n")
 	}
-	fullCmd = append(fullCmd, []string{"-m", "-U", "--preserve-credentials"}...)
+	fullCmd = append(fullCmd, "-m")
+	if userns {
+		fullCmd = append(fullCmd, []string{"-U", "--preserve-credentials"}...)
+	}
 	fullCmd = append(fullCmd, cmd...)
 	return fullCmd
+}
+
+func SameNS(pid [2]int, nsName string) (bool, error) {
+	var links [2]string
+	for i := 0; i < 2; i++ {
+		p := filepath.Join("/proc", strconv.Itoa(pid[i]), "ns", filepath.Clean(nsName))
+		var err error
+		links[i], err = os.Readlink(p)
+		if err != nil {
+			return false, err
+		}
+	}
+	return links[0] == links[1], nil
+}
+
+func SameUserNSAsCurrent(pid int) (bool, error) {
+	return SameNS([2]int{os.Getpid(), pid}, "user")
 }


### PR DESCRIPTION
On Ubuntu 25.04, `unshare` is subject to `/etc/apparmor.d/unshare-userns-restrict` that disables mounting.

```
$ rootlesskit --detach-netns bash
[rootlesskit:child ] error: failed to create a detached netns on "/tmp/rootlesskit2294453251/netns":
failed to execute [unshare -n mount --bind /proc/self/ns/net /tmp/rootlesskit2294453251/netns]:
exit status 32 (out="mount: /tmp/rootlesskit2294453251/netns: permission denied.\n       dmesg(1) may have more information after failed mount system call.\n")
```

Fix #494