### PR TITLE
Fix detach-netns permission error on Ubuntu 25.04

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
+	"github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit/unshare"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/child"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/copyup/tmpfssymlink"
@@ -41,6 +42,10 @@ const (
 )
 
 func main() {
+	if checkUnshareHelper() {
+		unshare.Main()
+		return
+	}
 	iAmActivationHelper := checkActivationHelper()
 	iAmChild := os.Getenv(pipeFDEnvKey) != ""
 	id := "parent"
@@ -700,4 +705,8 @@ func createActivationOpts(clicontext *cli.Context) (activation.Opt, error) {
 		TargetCmd:                 clicontext.Args().Slice(),
 	}
 	return opt, nil
+}
+
+func checkUnshareHelper() bool {
+	return filepath.Base(os.Args[0]) == "unshare"
 }

--- a/cmd/rootlesskit/unshare/unshare.go
+++ b/cmd/rootlesskit/unshare/unshare.go
@@ -1,0 +1,53 @@
+package unshare
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+func Main() {
+	app := cli.NewApp()
+	app.Name = "unshare"
+	app.HideHelpCommand = true
+	app.Version = version.Version
+	app.Usage = "Reimplementation of unshare(1)"
+	app.UsageText = "unshare [global options] [arguments...]"
+	app.Flags = append(app.Flags, &cli.BoolFlag{
+		Name:  "n,net",
+		Usage: "unshare network namespace",
+	})
+	app.Action = action
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "[rootlesskit:unshare] error: %v\n", err)
+		// propagate the exit code
+		code, ok := common.GetExecExitStatus(err)
+		if !ok {
+			code = 1
+		}
+		os.Exit(code)
+	}
+}
+
+func action(clicontext *cli.Context) error {
+	ctx := clicontext.Context
+	if clicontext.NArg() < 1 {
+		return errors.New("no command specified")
+	}
+	cmdFlags := clicontext.Args().Slice()
+	cmd := exec.CommandContext(ctx, cmdFlags[0], cmdFlags[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	if clicontext.Bool("n") {
+		cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNET
+	}
+	return cmd.Run()
+}

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -583,8 +583,16 @@ func NewNetNsWithPathWithoutEnter(p string) error {
 	if err := os.WriteFile(p, nil, 0400); err != nil {
 		return err
 	}
+	selfExe, err := os.Executable()
+	if err != nil {
+		return err
+	}
 	// this is hard (not impossible though) to reimplement in Go: https://github.com/cloudflare/slirpnetstack/commit/d7766a8a77f0093d3cb7a94bd0ccbe3f67d411ba
 	cmd := exec.Command("unshare", "-n", "mount", "--bind", "/proc/self/ns/net", p)
+	// Use our own implementation of unshare that is embedded in RootlessKit, so as to
+	// avoid /etc/apparmor.d/unshare-userns-restrict on Ubuntu 25.04.
+	// https://github.com/rootless-containers/rootlesskit/issues/494
+	cmd.Path = selfExe
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to execute %v: %w (out=%q)", cmd.Args, err, string(out))


### PR DESCRIPTION
On Ubuntu 25.04, `unshare` is subject to `/etc/apparmor.d/unshare-userns-restrict` that disables mounting.

```
$ rootlesskit --detach-netns bash
[rootlesskit:child ] error: failed to create a detached netns on "/tmp/rootlesskit2294453251/netns":
failed to execute [unshare -n mount --bind /proc/self/ns/net /tmp/rootlesskit2294453251/netns]:
exit status 32 (out="mount: /tmp/rootlesskit2294453251/netns: permission denied.\n       dmesg(1) may have more information after failed mount system call.\n")
```

Fix #494

Alternative to PR #495