### PR TITLE
Revert "detach-netns: simplify unshare helper"

### DIFF
--- a/cmd/rootlesskit/main.go
+++ b/cmd/rootlesskit/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
+	"github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit/unshare"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/child"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/copyup/tmpfssymlink"
@@ -41,6 +42,10 @@ const (
 )
 
 func main() {
+	if checkUnshareHelper() {
+		unshare.Main()
+		return
+	}
 	iAmActivationHelper := checkActivationHelper()
 	iAmChild := os.Getenv(pipeFDEnvKey) != ""
 	id := "parent"
@@ -700,4 +705,8 @@ func createActivationOpts(clicontext *cli.Context) (activation.Opt, error) {
 		TargetCmd:                 clicontext.Args().Slice(),
 	}
 	return opt, nil
+}
+
+func checkUnshareHelper() bool {
+	return filepath.Base(os.Args[0]) == "unshare"
 }

--- a/cmd/rootlesskit/unshare/unshare.go
+++ b/cmd/rootlesskit/unshare/unshare.go
@@ -1,0 +1,53 @@
+package unshare
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/rootless-containers/rootlesskit/v2/pkg/common"
+	"github.com/rootless-containers/rootlesskit/v2/pkg/version"
+	"github.com/urfave/cli/v2"
+)
+
+func Main() {
+	app := cli.NewApp()
+	app.Name = "unshare"
+	app.HideHelpCommand = true
+	app.Version = version.Version
+	app.Usage = "Reimplementation of unshare(1)"
+	app.UsageText = "unshare [global options] [arguments...]"
+	app.Flags = append(app.Flags, &cli.BoolFlag{
+		Name:  "n,net",
+		Usage: "unshare network namespace",
+	})
+	app.Action = action
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "[rootlesskit:unshare] error: %v\n", err)
+		// propagate the exit code
+		code, ok := common.GetExecExitStatus(err)
+		if !ok {
+			code = 1
+		}
+		os.Exit(code)
+	}
+}
+
+func action(clicontext *cli.Context) error {
+	ctx := clicontext.Context
+	if clicontext.NArg() < 1 {
+		return errors.New("no command specified")
+	}
+	cmdFlags := clicontext.Args().Slice()
+	cmd := exec.CommandContext(ctx, cmdFlags[0], cmdFlags[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	if clicontext.Bool("n") {
+		cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNET
+	}
+	return cmd.Run()
+}

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -583,13 +583,19 @@ func NewNetNsWithPathWithoutEnter(p string) error {
 	if err := os.WriteFile(p, nil, 0400); err != nil {
 		return err
 	}
-	tempNS, err := ns.TempNetNS()
+	selfExe, err := os.Executable()
 	if err != nil {
 		return err
 	}
-	defer tempNS.Close()
-	tempNSPath := tempNS.Path()
-	return ns.WithNetNSPath(tempNSPath, func(_ ns.NetNS) error {
-		return unix.Mount(tempNSPath, p, "", unix.MS_BIND, "")
-	})
+	// this is hard (not impossible though) to reimplement in Go: https://github.com/cloudflare/slirpnetstack/commit/d7766a8a77f0093d3cb7a94bd0ccbe3f67d411ba
+	cmd := exec.Command("unshare", "-n", "mount", "--bind", "/proc/self/ns/net", p)
+	// Use our own implementation of unshare that is embedded in RootlessKit, so as to
+	// avoid /etc/apparmor.d/unshare-userns-restrict on Ubuntu 25.04.
+	// https://github.com/rootless-containers/rootlesskit/issues/494
+	cmd.Path = selfExe
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to execute %v: %w (out=%q)", cmd.Args, err, string(out))
+	}
+	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.3.4"
+const Version = "2.3.4+dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.3.3+dev"
+const Version = "2.3.4"


### PR DESCRIPTION
This reverts commit 0dfe464daa35d7bfcfe28684b2a31acfd88a0a9f.


- - -
Revert:
- #497 

Due to a regression https://github.com/moby/buildkit/pull/5825#issuecomment-2709212950


> This might be a regression in v2.3.3
> 
> - [test / run (oci-rootless-slirp4netns-detachnetns, ./frontend/dockerfile, dockerfile)](https://github.com/moby/buildkit/actions/runs/13754657207/job/38460231004?pr=5825)
> 
> ```
> === FAIL: frontend/dockerfile TestIntegration (0.05s)
>     run.go:315: copied local:/mainline.tar to local mirror localhost:44447/buildkit_test/mtd7m2emwrrj5deqz9jduk2hb:latest
> time="2025-03-10T01:18:46Z" level=info msg="fetch failed after status: 404 Not Found" host="localhost:44447"
>     run.go:315: copied docker.io/amd64/alpine:latest@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 to local mirror localhost:44447/library/alpine:latest
> time="2025-03-10T01:18:47Z" level=info msg="fetch failed after status: 404 Not Found" host="localhost:44447"
>     run.go:315: copied docker.io/amd64/busybox:stable-musl to local mirror localhost:44447/library/busybox:stable-musl
> time="2025-03-10T01:18:48Z" level=info msg="fetch failed after status: 404 Not Found" host="localhost:44447"
>     run.go:315: copied docker.io/amd64/busybox:latest@sha256:023917ec6a886d0e8e15f28fb543515a5fcd8d938edb091e8147db4efed388ee to local mirror localhost:44447/library/busybox:latest
>     run.go:315: copied docker.io/amd64/debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75 to local mirror localhost:44947/amd64/debian:bullseye-20230109-slim
> ```
> 
> - [test / run (oci-rootless-slirp4netns-detachnetns, ./frontend/dockerfile, integration)](https://github.com/moby/buildkit/actions/runs/13754657207/job/38460230825?pr=5825)
> ```
> == FAIL: frontend/dockerfile TestIntegration (0.09s)
>     run.go:315: copied docker.io/amd64/alpine:latest@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70 to local mirror localhost:42351/library/alpine:latest
> time="2025-03-10T01:18:45Z" level=info msg="fetch failed after status: 404 Not Found" host="localhost:42351"
>     run.go:315: copied docker.io/amd64/busybox:stable-musl to local mirror localhost:42351/library/busybox:stable-musl
> time="2025-03-10T01:18:46Z" level=info msg="fetch failed after status: 404 Not Found" host="localhost:42351"
>     run.go:315: copied docker.io/amd64/busybox:latest@sha256:023917ec6a886d0e8e15f28fb543515a5fcd8d938edb091e8147db4efed388ee to local mirror localhost:42351/library/busybox:latest
>     run.go:315: copied docker.io/amd64/debian:bullseye-20230109-slim@sha256:1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75 to local mirror localhost:35903/amd64/debian:bullseye-20230109-slim
> ```
> 
> - [test / run (oci-rootless-slirp4netns-detachnetns, ./client ./cmd/buildctl ./worker/containerd ./solver ....](https://github.com/moby/buildkit/actions/runs/13754657210/job/38460299877?pr=5825#logs)
> ```
> 
> === FAIL: frontend TestFrontendIntegration/TestRefStatFile/worker=oci-rootless-slirp4netns-detachnetns (15.12s)
>     run.go:238: 
>         	Error Trace:	/src/util/testutil/integration/run.go:238
>         	Error:      	Received unexpected error:
>         	            	failed dialing: /tmp/bktest_buildkitd3359171510/buildkitd.sock
>         	            	github.com/moby/buildkit/util/testutil/integration.WaitSocket
>         	            		/src/util/testutil/integration/util.go:138
>         	            	github.com/moby/buildkit/util/testutil/workers.runBuildkitd
>         	            		/src/util/testutil/workers/util.go:115
>         	            	github.com/moby/buildkit/util/testutil/workers.(*OCI).New
>         	            		/src/util/testutil/workers/oci.go:85
>         	            	github.com/moby/buildkit/util/testutil/integration.newSandbox
>         	            		/src/util/testutil/integration/sandbox.go:127
>         	            	github.com/moby/buildkit/util/testutil/integration.Run.func2.1
>         	            		/src/util/testutil/integration/run.go:237
>         	            	testing.tRunner
>         	            		/usr/local/go/src/testing/testing.go:1690
>         	            	runtime.goexit
>         	            		/usr/local/go/src/runtime/asm_amd64.s:1700
>         	            	creating worker
>         	            	github.com/moby/buildkit/util/testutil/integration.newSandbox
>         	            		/src/util/testutil/integration/sandbox.go:129
>         	            	github.com/moby/buildkit/util/testutil/integration.Run.func2.1
>         	            		/src/util/testutil/integration/run.go:237
>         	            	testing.tRunner
>         	            		/usr/local/go/src/testing/testing.go:1690
>         	            	runtime.goexit
>         	            		/usr/local/go/src/runtime/asm_amd64.s:1700
>         	Test:       	TestFrontendIntegration/TestRefStatFile/worker=oci-rootless-slirp4netns-detachnetns
> 2025/03/10 01:21:19 stdout: /usr/bin/sudo -u #1000 -i -- exec rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback --detach-netns buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config3279013865/buildkitd.toml --root /tmp/bktest_buildkitd43008409 --addr unix:///tmp/bktest_buildkitd43008409/buildkitd.sock --debug
> 2025/03/10 01:21:19 stderr: /usr/bin/sudo -u #1000 -i -- exec rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback --detach-netns buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config3279013865/buildkitd.toml --root /tmp/bktest_buildkitd43008409 --addr unix:///tmp/bktest_buildkitd43008409/buildkitd.sock --debug
> 2025/03/10 01:21:19 > StartCmd 2025-03-10 01:21:04.558913329 +0000 UTC m=+0.030075216 /usr/bin/sudo -u #1000 -i -- exec rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback --detach-netns buildkitd --oci-worker=true --containerd-worker=false --oci-worker-gc=false --oci-worker-labels=org.mobyproject.buildkit.worker.sandbox=true --config=/tmp/bktest_config3279013865/buildkitd.toml --root /tmp/bktest_buildkitd43008409 --addr unix:///tmp/bktest_buildkitd43008409/buildkitd.sock --debug
> 2025/03/10 01:21:19 [rootlesskit:child ] error: failed to create a detached netns on "/tmp/rootlesskit2584759687/netns": failed to Statfs "/proc/14943/task/15004/ns/net": no such file or directory
> 2025/03/10 01:21:19 > sending sigterm 2025-03-10 01:21:19.6604122 +0000 UTC m=+15.131574057
> 2025/03/10 01:21:19 > sending SIGTERM 2025-03-10 01:21:19.660419885 +0000 UTC m=+15.131581741
> 2025/03/10 01:21:19 > stopped 2025-03-10 01:21:19.661570195 +0000 UTC m=+15.132732052 signal: terminated -1
>     --- FAIL: TestFrontendIntegration/TestRefStatFile/worker=oci-rootless-slirp4netns-detachnetns (15.12s)
> ```

_Originally posted by @AkihiroSuda in https://github.com/moby/buildkit/issues/5825#issuecomment-2709212950_
            