### PR TITLE
ci: fix missing tag variable in release note generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
       run: sha256sum /tmp/SHA256SUMS
     - name: "Prepare the release note"
       run: |
+        tag="${GITHUB_REF##*/}"
         shasha=$(sha256sum /tmp/SHA256SUMS | awk '{print $1}')
         cat << EOF | tee /tmp/release-note.txt
         #### Changes


### PR DESCRIPTION
### What I did

- Added `tag="${GITHUB_REF##*/}"` to the `Prepare the release note` step in `.github/workflows/release.yaml`.

### Why

At the time of the v2.3.5 release, the generated release note contained an empty tag placeholder in the download URL, e.g.: `curl -sSL https://github.com/rootless-containers/rootlesskit/releases/download//rootlesskit-$(uname -m).tar.gz`

This change ensures that `${tag}` is correctly set and expands to the current release tag (e.g., `v3.0.0`), so that the release note contains a valid download URL.

### Example

After this fix, the generated note will correctly include the tag: `curl -sSL https://github.com/rootless-containers/rootlesskit/releases/download/v3.0.0/rootlesskit-$(uname -m).tar.gz | tar Cxzv ~/bin`


### QA

Verified in my own sandbox repository:  https://github.com/yoshikawa/sandbox/releases/tag/untagged-e0f32bf5925c75582d17

Steps to reproduce:
```sh
git tag -a v0.0.7 -m "v0.0.7" 5d93db9
git push origin v0.0.7
# Verified the GitHub Actions run:
# https://github.com/yoshikawa/sandbox/actions/runs/19010835989/job/54291534935#step:7:28
```