### PR TITLE
fix: remove Setsid from runWithoutReap to restore TTY

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,6 +54,8 @@ jobs:
       run: docker run --rm --net=none --privileged rootlesskit:test-integration ./integration-systemd-socket.sh
     - name: "Integration test: pdeathsig"
       run: docker run --rm --privileged rootlesskit:test-integration ./integration-pdeathsig.sh
+    - name: "Integration test: runWithoutReap"
+      run: docker run --rm --privileged rootlesskit:test-integration ./integration-run-without-reap.sh
     - name: "Integration test: Network (network driver=slirp4netns)"
       run: |
         docker run --rm --privileged rootlesskit:test-integration ./integration-net.sh slirp4netns

--- a/hack/integration-run-without-reap.sh
+++ b/hack/integration-run-without-reap.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Integration test for runWithoutReap (--reaper=false path).
+# Regression test for https://github.com/rootless-containers/rootlesskit/issues/557
+source $(realpath $(dirname $0))/common.inc.sh
+
+INFO "Testing runWithoutReap: command execution"
+out=$($ROOTLESSKIT --reaper=false echo hello 2>&1)
+if ! echo "$out" | grep -q "hello"; then
+	ERROR "expected 'hello' in output, got: $out"
+	exit 1
+fi
+
+INFO "Testing runWithoutReap: exit code propagation"
+set +e
+$ROOTLESSKIT --reaper=false sh -c "exit 42" >/dev/null 2>&1
+code=$?
+set -e
+if [ $code != 42 ]; then
+	ERROR "expected exit code 42, got $code"
+	exit 1
+fi
+
+INFO "Testing runWithoutReap: TTY preservation"
+# Use script(1) to allocate a PTY; verify the child sees a TTY
+# and does not print "cannot set terminal process group" (issue #557).
+tmp=$(mktemp -d)
+script -qec "$ROOTLESSKIT --reaper=false sh -c 'tty; echo DONE'" "$tmp/typescript" > "$tmp/out" 2>&1
+if grep -qi "cannot set terminal process group" "$tmp/out"; then
+	ERROR "child lost its controlling terminal (setsid regression)"
+	cat "$tmp/out"
+	rm -rf "$tmp"
+	exit 1
+fi
+if ! grep -q "DONE" "$tmp/out"; then
+	ERROR "child did not complete"
+	cat "$tmp/out"
+	rm -rf "$tmp"
+	exit 1
+fi
+rm -rf "$tmp"
+
+INFO "===== All runWithoutReap tests passed ====="

--- a/pkg/child/child.go
+++ b/pkg/child/child.go
@@ -542,7 +542,6 @@ func setMountPropagation(propagation string) error {
 }
 
 func runWithoutReap(cmd *exec.Cmd) error {
-	cmd.SysProcAttr.Setsid = true
 	if err := cmd.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit 2ca0537 added `Setsid=true` in `runWithoutReap()` as part of the Pdeathsig implementation, but Pdeathsig doesn't actually need it. `Setsid` creates a new session which detaches the child from the terminal, so bash loses its TTY and prints:

```
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
```

This PR simply removes `Setsid=true` from the non-reaping path. The reaping path (`runAndReap`) keeps it because it needs session isolation to reap zombie processes.

Fixes #557