### PR TITLE
rootlesskit-docker-proxy: postpone removal to v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bin/rootlessctl: $(GO_FILES)
 
 bin/rootlesskit-docker-proxy: $(GO_FILES)
 	@echo "NOTE: rootlesskit-docker-proxy is required only if you use Docker prior to v28."
-	@echo "NOTE: rootlesskit-docker-proxy is DEPRECATED and will be removed in RootlessKit v3."
+	@echo "NOTE: rootlesskit-docker-proxy is DEPRECATED and will be removed in RootlessKit v4."
 	$(GO) build -o $@ -v ./cmd/rootlesskit-docker-proxy
 
 .PHONY: cross

--- a/cmd/rootlesskit-docker-proxy/main.go
+++ b/cmd/rootlesskit-docker-proxy/main.go
@@ -6,7 +6,7 @@
 //
 // https://github.com/moby/moby/pull/48132/commits/dac7ffa3404138a4f291c16586e5a2c68dad4151
 //
-// rootlesskit-docker-proxy will be removed in RootlessKit v3.
+// rootlesskit-docker-proxy will be removed in RootlessKit v4.
 package main
 
 import (


### PR DESCRIPTION
rootlesskit-docker-proxy is deprecated and no longer needed for Docker since Docker v28, however, there might be still somebody using Docker prior to v28.