### PR TITLE
docs/network.md: lxc-user-nic seems to work with detach-netns

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -190,7 +190,6 @@ Cons:
 * Less secure
 * Needs `/etc/lxc/lxc-usernet` configuration
 * No support for IPv6.
-* No support for `--detach-netns`
 
 To use `lxc-user-nic`, you need to install `liblxc-common` package:
 ```console


### PR DESCRIPTION
Tested with Rootless Docker v29.5 and nerdctl v2.3 on Ubuntu 26.04.