### PR TITLE
api: expose IPv6 capability in NetworkDriverInfo

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,7 +5,7 @@ import "net"
 const (
 	// Version of the REST API, not implementation version.
 	// See openapi.yaml for the definition.
-	Version = "1.1.1"
+	Version = "1.1.2"
 )
 
 // Info is the structure returned by `GET /info`
@@ -24,6 +24,7 @@ type NetworkDriverInfo struct {
 	DNS            []net.IP `json:"dns,omitempty"`
 	ChildIP        net.IP   `json:"childIP,omitempty"`        // since API v1.1.1 (RootlessKit v0.14.1)
 	DynamicChildIP bool     `json:"dynamicChildIP,omitempty"` // since API v1.1.1
+	IPv6           bool     `json:"ipv6,omitempty"`           // since API v1.1.2
 }
 
 // PortDriverInfo in Info

--- a/pkg/api/openapi.yaml
+++ b/pkg/api/openapi.yaml
@@ -1,7 +1,7 @@
 # When you made a change to this YAML, please validate with https://editor.swagger.io
 openapi: 3.0.3
 info:
-  version: 1.1.1
+  version: 1.1.2
   title: RootlessKit API
 servers:
   - url: 'http://rootlesskit/v1'
@@ -151,6 +151,9 @@ components:
         dynamicChildIP:
           type: boolean
           description: "Child IP may change"
+        ipv6:
+          type: boolean
+          description: "Whether the network driver has IPv6 enabled"
     PortDriverInfo:
       required:
         - driver

--- a/pkg/network/gvisortapvsock/gvisortapvsock.go
+++ b/pkg/network/gvisortapvsock/gvisortapvsock.go
@@ -91,6 +91,7 @@ func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 	if infoFn == nil {
 		return &api.NetworkDriverInfo{
 			Driver: DriverName,
+			IPv6:   d.enableIPv6,
 		}, nil
 	}
 
@@ -204,6 +205,7 @@ func (d *parentDriver) updateDriverInfo(netmsg *messages.ParentInitNetworkDriver
 			DNS:            apiDNS,
 			ChildIP:        net.ParseIP(netmsg.IP),
 			DynamicChildIP: false,
+			IPv6:           d.enableIPv6,
 		}
 	}
 	d.infoMu.Unlock()

--- a/pkg/network/pasta/pasta.go
+++ b/pkg/network/pasta/pasta.go
@@ -115,6 +115,7 @@ func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 	if infoFn == nil {
 		return &api.NetworkDriverInfo{
 			Driver: DriverName,
+			IPv6:   d.enableIPv6,
 		}, nil
 	}
 
@@ -220,6 +221,7 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 			DNS:            []net.IP{net.ParseIP(netmsg.DNS[0])},
 			ChildIP:        net.ParseIP(netmsg.IP),
 			DynamicChildIP: false,
+			IPv6:           d.enableIPv6,
 		}
 	}
 	d.infoMu.Unlock()

--- a/pkg/network/slirp4netns/slirp4netns.go
+++ b/pkg/network/slirp4netns/slirp4netns.go
@@ -166,6 +166,7 @@ func (d *parentDriver) Info(ctx context.Context) (*api.NetworkDriverInfo, error)
 	if infoFn == nil {
 		return &api.NetworkDriverInfo{
 			Driver: DriverName,
+			IPv6:   d.enableIPv6,
 		}, nil
 	}
 
@@ -292,6 +293,7 @@ func (d *parentDriver) ConfigureNetwork(childPID int, stateDir, detachedNetNSPat
 			DNS:            apiDNS,
 			ChildIP:        net.ParseIP(netmsg.IP),
 			DynamicChildIP: false,
+			IPv6:           d.enableIPv6,
 		}
 	}
 	d.infoMu.Unlock()


### PR DESCRIPTION
Adds an `IPv6` bool to `NetworkDriverInfo` in the API. This gives consumers (like nerdctl) a proper way to check for IPv6 support instead of parsing CLI help text.

- Added `IPv6` field to `api.go` and `openapi.yaml`
- Updated `gvisortapvsock`, `pasta`, and `slirp4netns` drivers to expose their `enableIPv6` state

Ref: https://github.com/containerd/nerdctl/pull/5055#discussion_r3548420865