### PR TITLE
fix: benchmark pasta, not slirp4netns

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -9,17 +9,17 @@ RootlessKit provides several drivers for providing network connectivity:
 * `--net=lxc-user-nic`: use `lxc-user-nic` (experimental)
 * `--net=gvisor-tap-vsock`: use [gvisor-tap-vsock](https://github.com/containers/gvisor-tap-vsock) (experimental)
 
-[Benchmark: iperf3 from the child to the parent (Apr 10, 2026)](https://github.com/rootless-containers/rootlesskit/actions/runs/24200485791/job/70642399211):
+[Benchmark: iperf3 from the child to the parent (Jul 26, 2026)](https://github.com/rootless-containers/rootlesskit/actions/runs/30191669102/job/89765864664):
 
 |                 Driver                |  MTU=1500  |  MTU=65520
 |---------------------------------------|------------|-------------
-|`slirp4netns`                          |  0.84 Gbps |  6.17 Gbps
-|`slirp4netns` (with sandbox + seccomp) |  0.80 Gbps |  6.19 Gbps
-|`vpnkit`                               |  0.10 Gbps |(Unsupported)
-|`pasta`                                |  0.87 Gbps |  6.48 Gbps
-|`gvisor-tap-vsock`                     |  1.55 Gbps |  5.40 Gbps
-|`lxc-user-nic`                         |  29.3 Gbps |  30.4 Gbps
-|(rootful veth)                         | (35.0 Gbps)| (36.2 Gbps)
+|`slirp4netns`                          |  1.69 Gbps |  8.11 Gbps
+|`slirp4netns` (with sandbox + seccomp) |  1.68 Gbps |  8.32 Gbps
+|`vpnkit`                               |  0.14 Gbps |(Unsupported)
+|`pasta`                                |  0.24 Gbps |  31.9 Gbps
+|`gvisor-tap-vsock`                     |  2.46 Gbps |  8.75 Gbps
+|`lxc-user-nic`                         |  49.1 Gbps |  50.7 Gbps
+|(rootful veth)                         | (49.3 Gbps)| (50.8 Gbps)
 
 * To be documented: [`bypass4netns`](https://github.com/rootless-containers/bypass4netns) for native performance.
 

--- a/hack/benchmark-iperf3-net.sh
+++ b/hack/benchmark-iperf3-net.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 source $(realpath $(dirname $0))/common.inc.sh
 function benchmark::iperf3::pasta() {
-	INFO "[benchmark:iperf3] slirp4netns ($@)"
+	INFO "[benchmark:iperf3] pasta ($@)"
 	statedir=$(mktemp -d)
 	if echo "$@" | grep -q -- --detach-netns; then
 		IPERF3C="nsenter -n${statedir}/netns $IPERF3C"
 	fi
 	set -x
-	$ROOTLESSKIT --state-dir=$statedir --net=slirp4netns $@ -- $IPERF3C 10.0.2.2
+	$ROOTLESSKIT --state-dir=$statedir --net=pasta $@ -- $IPERF3C 10.0.2.2
 	set +x
 }
 


### PR DESCRIPTION
The `benchmark::iperf3::pasta` function was running rootlesskit with `--net=slirp4netns`

As a result, the **Benchmark: Network (MTU=65520, network driver=pasta)** jobs in the CI have been measuring `slirp4netns`, not `pasta`.

After applying this fix, `./benchmark-iperf3-net.sh pasta 65520` benchmarks `rootlesskit --state-dir=<state> --net=pasta --mtu=65520 -- iperf3 -t 30 -c 10.0.2.2`

<details><summary>Details</summary>
<p>

```bash
> sudo nerdctl build -t rootlesskit:test-integration --target test-integration .
...

> sudo nerdctl run --rm --net=host --privileged rootlesskit:test-integration ./benchmark-iperf3-net.sh pasta 65520
[INFO] net=pasta mtu=65520 flags=
[INFO] [benchmark:iperf3] pasta (--mtu=65520)
+ rootlesskit --state-dir=/tmp/tmp.8bulVrezku --net=pasta --mtu=65520 -- iperf3 -t 30 -c 10.0.2.2
time="2026-07-26T06:50:26Z" level=warning msg="[rootlesskit:parent] specifying --disable-host-loopback is highly recommended to prohibit connecting to 127.0.0.1:* on the host namespace (requires pasta, slirp4netns, or VPNKit)"
time="2026-07-26T06:50:26Z" level=warning msg="[rootlesskit:parent] \"pasta\" network driver is experimental. Needs very recent version of pasta (see docs/network.md)."
time="2026-07-26T06:50:26Z" level=warning msg="[rootlesskit:child ] Mounting /etc/resolv.conf without copying-up /etc. Note that /etc/resolv.conf in the namespace will be unmounted when it is recreated on the host. Unless /etc/resolv.conf is statically configured, copying-up /etc is highly recommended. Please refer to RootlessKit documentation for further information."
Connecting to host 10.0.2.2, port 5201
[  6] local 10.0.2.100 port 44152 connected to 10.0.2.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  6]   0.00-1.00   sec  1.38 GBytes  11.8 Gbits/sec  204   4.28 MBytes
[  6]   1.00-2.00   sec  6.19 GBytes  53.1 Gbits/sec  136   2.93 MBytes
[  6]   2.00-3.00   sec  5.97 GBytes  51.3 Gbits/sec   68   4.16 MBytes
[  6]   3.00-4.00   sec  5.96 GBytes  51.1 Gbits/sec  136   4.22 MBytes
[  6]   4.00-5.00   sec  5.65 GBytes  48.6 Gbits/sec   68   4.16 MBytes
[  6]   5.00-6.00   sec  9.45 GBytes  81.3 Gbits/sec   46   4.10 MBytes
[  6]   6.00-7.00   sec  5.60 GBytes  47.9 Gbits/sec   71    120 KBytes
[  6]   7.00-8.00   sec  7.35 GBytes  63.2 Gbits/sec   65   4.16 MBytes
[  6]   8.00-9.00   sec  5.39 GBytes  46.5 Gbits/sec   98   4.28 MBytes
[  6]   9.00-10.00  sec  8.21 GBytes  70.3 Gbits/sec    0   4.28 MBytes
[  6]  10.00-11.00  sec  7.13 GBytes  61.4 Gbits/sec  138   4.28 MBytes
[  6]  11.00-12.00  sec  10.1 GBytes  86.5 Gbits/sec    0   4.28 MBytes
[  6]  12.00-13.00  sec  9.70 GBytes  83.4 Gbits/sec    0   4.28 MBytes
[  6]  13.00-14.00  sec  8.32 GBytes  71.3 Gbits/sec    0   4.28 MBytes
[  6]  14.00-15.00  sec  5.27 GBytes  45.3 Gbits/sec  137   4.16 MBytes
[  6]  15.00-16.00  sec  7.34 GBytes  63.0 Gbits/sec   55   4.10 MBytes
[  6]  16.00-17.00  sec  3.86 GBytes  33.2 Gbits/sec  104   2.11 MBytes
[  6]  17.00-18.00  sec  8.58 GBytes  73.7 Gbits/sec   36   4.28 MBytes
[  6]  18.00-19.00  sec  7.48 GBytes  64.3 Gbits/sec   69   4.28 MBytes
[  6]  19.00-20.00  sec  8.36 GBytes  71.8 Gbits/sec   16    180 KBytes
[  6]  20.00-21.00  sec  8.88 GBytes  76.3 Gbits/sec    3   4.16 MBytes
[  6]  21.00-22.00  sec  8.67 GBytes  74.3 Gbits/sec    0   4.16 MBytes
[  6]  22.00-23.00  sec  6.43 GBytes  55.4 Gbits/sec  119   4.22 MBytes
[  6]  23.00-24.00  sec  9.05 GBytes  77.8 Gbits/sec    0   4.22 MBytes
[  6]  24.00-25.00  sec  10.2 GBytes  87.6 Gbits/sec    0   4.22 MBytes
[  6]  25.00-26.00  sec  8.43 GBytes  72.3 Gbits/sec    0   4.22 MBytes
[  6]  26.00-27.00  sec  6.20 GBytes  53.3 Gbits/sec  117   4.10 MBytes
[  6]  27.00-28.00  sec  9.92 GBytes  85.2 Gbits/sec    0   4.10 MBytes
[  6]  28.00-29.00  sec  6.28 GBytes  53.9 Gbits/sec   79    180 KBytes
[  6]  29.00-30.00  sec  7.57 GBytes  64.8 Gbits/sec    3   4.10 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  6]   0.00-30.00  sec   219 GBytes  62.7 Gbits/sec  1768             sender
[  6]   0.00-30.00  sec   219 GBytes  62.7 Gbits/sec                  receiver

iperf Done.
+ set +x
iperf3: interrupt - the server has terminated
```

</p>
</details> 

Note that since updating the benchmark script changes the benchmark results, I have also updated the documentation.