### PR TITLE
docs: refresh port driver benchmark table

### DIFF
--- a/docs/port.md
+++ b/docs/port.md
@@ -6,13 +6,13 @@ The default value is `none` (do not expose ports).
 
 | `--port-driver`      |  Throughput | Source IP | Notes
 |----------------------|-------------|----------|-------
-| `slirp4netns`        | 8.03 Gbps   | Propagated |
-| `builtin`            | 29.9 Gbps   | Propagated for TCP (since v3.0) | Source IP propagation (`--source-ip-transparent`) applies to TCP only; UDP is not propagated. In the case of Rootless Docker, userland-proxy has to be disabled for propagating the source IP.
-| `implicit`           | 37.6 Gbps   | Propagated | Requires `pasta` network
-| `pesto` (Experimental) | TBD       | Propagated | Requires `pasta` network and passt `2026_05_07.1afd4ed` or later. Supports explicit port management through `rootlessctl`.
-| `gvisor-tap-vsock` (Experimental) | 3.83 Gbps | Not propagated | Throughput is currently limited; see issue link below for improvement ideas.
+| `slirp4netns`        | 7.56 Gbps   | Propagated |
+| `builtin`            | 29.3 Gbps   | Propagated for TCP (since v3.0) | Source IP propagation (`--source-ip-transparent`) applies to TCP only; UDP is not propagated. In the case of Rootless Docker, userland-proxy has to be disabled for propagating the source IP.
+| `implicit`           | 39.9 Gbps   | Propagated | Requires `pasta` network
+| `pesto` (Experimental) | 45.2 Gbps | Propagated | Requires `pasta` network and passt `2026_05_07.1afd4ed` or later. Supports explicit port management through `rootlessctl`.
+| `gvisor-tap-vsock` (Experimental) | 3.77 Gbps | Not propagated | Throughput is currently limited; see issue link below for improvement ideas.
 
-Benchmark: iperf3 from the parent to the child is measured on GitHub Actions ([Apr 10, 2026](https://github.com/rootless-containers/rootlesskit/actions/runs/24200485791/job/70642399211))
+Benchmark: iperf3 from the parent to the child is measured on GitHub Actions ([Aug 4, 2026](https://github.com/rootless-containers/rootlesskit/actions/runs/30896585927/job/91950824205))
 
 The `builtin` driver is fast and should be the best choice for most use cases.
 


### PR DESCRIPTION
followup: https://github.com/rootless-containers/rootlesskit/pull/616